### PR TITLE
Add physics, terrain, ECS, and quality settings foundation

### DIFF
--- a/Assets/Shaders/2D/FragmentShader.glsl
+++ b/Assets/Shaders/2D/FragmentShader.glsl
@@ -8,53 +8,35 @@ in vec2 texCoordF;
 flat in uint texIndexF;
 
 uniform sampler2D tex0, tex1, tex2, tex3, tex4, tex5, tex6, tex7, tex8, tex9, tex10, tex11, tex12, tex13, tex14, tex15;
-//uniform sampler2D tex15, tex16, tex17, tex18, tex19, tex20, tex21, tex22, tex23, tex24, tex25, tex26, tex27, tex28, tex29;
-//uniform sampler2D tex30, tex31;
-
 
 void main()
 {
-    float ambient = 0.1;
-    
-    switch (int(texIndexF))
-    {
-        case 0: fragColor = colorF;
-        case 1: fragColor = colorF * texture(tex0, texCoordF); break;
-        case 2: fragColor = colorF * texture(tex1, texCoordF); break;
-        case 3: fragColor = colorF * texture(tex2, texCoordF); break;
-        case 4: fragColor = colorF * texture(tex3, texCoordF); break;
-        case 5: fragColor = colorF * texture(tex4, texCoordF); break;
-        case 6: fragColor = colorF * texture(tex5, texCoordF); break;
-        case 7: fragColor = colorF * texture(tex6, texCoordF); break;
-        case 8: fragColor = colorF * texture(tex7, texCoordF); break;
-        case 9: fragColor = colorF * texture(tex8, texCoordF); break;
-        case 10: fragColor = colorF * texture(tex9, texCoordF); break;
-        case 11: fragColor = colorF * texture(tex10, texCoordF); break;
-        case 12: fragColor = colorF * texture(tex11, texCoordF); break;
-        case 13: fragColor = colorF * texture(tex12, texCoordF); break;
-        case 14: fragColor = colorF * texture(tex13, texCoordF); break;
-        case 15: fragColor = colorF * texture(tex14, texCoordF); break;
-        case 16: fragColor = colorF * texture(tex15, texCoordF); break;
-        
-    /*
-        
-        case 18: fragColor = colorF * texture(tex17, texCoordF); break;
-        case 19: fragColor = colorF * texture(tex18, texCoordF); break;
-        case 20: fragColor = colorF * texture(tex19, texCoordF); break;
-        case 21: fragColor = colorF * texture(tex20, texCoordF); break;
-        case 22: fragColor = colorF * texture(tex21, texCoordF); break;
-        case 23: fragColor = colorF * texture(tex22, texCoordF); break;
-        case 24: fragColor = colorF * texture(tex23, texCoordF); break;
-        case 25: fragColor = colorF * texture(tex24, texCoordF); break;
-        case 26: fragColor = colorF * texture(tex25, texCoordF); break;
-        case 27: fragColor = colorF * texture(tex26, texCoordF); break;
-        case 28: fragColor = colorF * texture(tex27, texCoordF); break;
-        case 29: fragColor = colorF * texture(tex28, texCoordF); break;
-        case 30: fragColor = colorF * texture(tex29, texCoordF); break;
-        case 31: fragColor = colorF * texture(tex30, texCoordF); break;
-        case 32: fragColor = colorF * texture(tex31, texCoordF); break;
-    */
-        
-    }
+    // texIndex 0 => vertex colour only; 1..16 => modulate with the bound texture.
+    vec4 base = colorF;
+    int ti = int(texIndexF);
+    if      (ti == 1)  base = colorF * texture(tex0,  texCoordF);
+    else if (ti == 2)  base = colorF * texture(tex1,  texCoordF);
+    else if (ti == 3)  base = colorF * texture(tex2,  texCoordF);
+    else if (ti == 4)  base = colorF * texture(tex3,  texCoordF);
+    else if (ti == 5)  base = colorF * texture(tex4,  texCoordF);
+    else if (ti == 6)  base = colorF * texture(tex5,  texCoordF);
+    else if (ti == 7)  base = colorF * texture(tex6,  texCoordF);
+    else if (ti == 8)  base = colorF * texture(tex7,  texCoordF);
+    else if (ti == 9)  base = colorF * texture(tex8,  texCoordF);
+    else if (ti == 10) base = colorF * texture(tex9,  texCoordF);
+    else if (ti == 11) base = colorF * texture(tex10, texCoordF);
+    else if (ti == 12) base = colorF * texture(tex11, texCoordF);
+    else if (ti == 13) base = colorF * texture(tex12, texCoordF);
+    else if (ti == 14) base = colorF * texture(tex13, texCoordF);
+    else if (ti == 15) base = colorF * texture(tex14, texCoordF);
+    else if (ti == 16) base = colorF * texture(tex15, texCoordF);
 
+    // Simple directional (sun) lighting using the interpolated normal, plus a
+    // flat ambient term so shadowed faces never go fully black.
+    vec3 N = normalize(normalF);
+    vec3 L = normalize(vec3(0.45, 0.85, 0.35));
+    float diffuse = max(dot(N, L), 0.0);
+    float lighting = 0.30 + 0.70 * diffuse;
+
+    fragColor = vec4(base.rgb * lighting, base.a);
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(USE_SDL2_MIXER "Force using SDL2_mixer as audio backend")
 #   - the place where your C/C++ source files are located
 #
 set(C_CXX_SOURCES_DIR_Physics "K.Engine.Physics/src")
+set(C_CXX_SOURCES_DIR_Terrain "K.Engine.Terrain/src")
 set(C_CXX_SOURCES_DIR_Graphics "K.Engine.Graphics/src")
 set(C_CXX_SOURCES_DIR_Audio "K.Engine.Audio/src")
 set(C_CXX_SOURCES_DIR_Core "K.Engine.Core/src")
@@ -33,6 +34,7 @@ set(C_CXX_SOURCES_DIR_imgui "ImGui")
 #   - the place where your C/C++ header files are located
 #
 set(C_CXX_HEADERS_DIR_Physics "K.Engine.Physics/include")
+set(C_CXX_HEADERS_DIR_Terrain "K.Engine.Terrain/include")
 set(C_CXX_HEADERS_DIR_Graphics "K.Engine.Graphics/include")
 set(C_CXX_HEADERS_DIR_Audio "K.Engine.Audio/include")
 set(C_CXX_HEADERS_DIR_Core "K.Engine.Core/include")
@@ -83,6 +85,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_PROFILE "${CMAKE_BINARY_DIR}/bin")
 
 set(SOURCE_DATA_DIR        ${CMAKE_CURRENT_SOURCE_DIR}/${ASSETS_DIR})
 set(SOURCE_CXX_INCLUDE_DIR_Physics ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_HEADERS_DIR_Physics})
+set(SOURCE_CXX_INCLUDE_DIR_Terrain ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_HEADERS_DIR_Terrain})
 set(SOURCE_CXX_INCLUDE_DIR_Graphics ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_HEADERS_DIR_Graphics})
 set(SOURCE_CXX_INCLUDE_DIR_Audio ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_HEADERS_DIR_Audio})
 set(SOURCE_CXX_INCLUDE_DIR_Core ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_HEADERS_DIR_Core})
@@ -93,6 +96,7 @@ set(IMGUI                          ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_HEADERS_D
 set(glm                           ${CMAKE_CURRENT_SOURCE_DIR}/glm)          
 
 set(SOURCE_CXX_SRC_DIR_Physics     ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_SOURCES_DIR_Physics})
+set(SOURCE_CXX_SRC_DIR_Terrain     ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_SOURCES_DIR_Terrain})
 set(SOURCE_CXX_SRC_DIR_Graphics    ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_SOURCES_DIR_Graphics})
 set(SOURCE_CXX_SRC_DIR_Audio       ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_SOURCES_DIR_Audio})
 set(SOURCE_CXX_SRC_DIR_Core        ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_SOURCES_DIR_Core})
@@ -105,7 +109,7 @@ set(SOURCE_CXX_SRC_DIR_imgui       ${CMAKE_CURRENT_SOURCE_DIR}/${C_CXX_SOURCES_D
 # Source Files are Curated Here
 file(
     GLOB_RECURSE SOURCE_CXX_FILES
-    "${SOURCE_CXX_SRC_DIR_Physics}/*.cpp" "${SOURCE_CXX_SRC_DIR_Graphics}/*.cpp" "${SOURCE_CXX_SRC_DIR_imgui}/*.cpp" "${SOURCE_CXX_SRC_DIR_Audio}/*.cpp" "${SOURCE_CXX_SRC_DIR_Core}/*.cpp" "${SOURCE_CXX_SRC_DIR_Common}/*.cpp" "${SOURCE_CXX_SRC_DIR_Editor}/*.cpp" "${SOURCE_CXX_SRC_DIR_Input}/*.cpp"
+    "${SOURCE_CXX_SRC_DIR_Physics}/*.cpp" "${SOURCE_CXX_SRC_DIR_Terrain}/*.cpp" "${SOURCE_CXX_SRC_DIR_Graphics}/*.cpp" "${SOURCE_CXX_SRC_DIR_imgui}/*.cpp" "${SOURCE_CXX_SRC_DIR_Audio}/*.cpp" "${SOURCE_CXX_SRC_DIR_Core}/*.cpp" "${SOURCE_CXX_SRC_DIR_Common}/*.cpp" "${SOURCE_CXX_SRC_DIR_Editor}/*.cpp" "${SOURCE_CXX_SRC_DIR_Input}/*.cpp"
 )
 
 # Include Directories
@@ -166,7 +170,7 @@ endif() # Emscripten
 ######################################################################
 # Set include directory
 ######################################################################
-target_include_directories(${OutputExecutable} PRIVATE ${IMGUI} ${glm} ${SOURCE_CXX_INCLUDE_DIR_Physics} ${SOURCE_CXX_INCLUDE_DIR_Graphics} ${SOURCE_CXX_INCLUDE_DIR_Audio} ${SOURCE_CXX_INCLUDE_DIR_Core} ${SOURCE_CXX_INCLUDE_DIR_Common} ${SOURCE_CXX_INCLUDE_DIR_Editor} ${SOURCE_CXX_INCLUDE_DIR_Input})
+target_include_directories(${OutputExecutable} PRIVATE ${IMGUI} ${glm} ${SOURCE_CXX_INCLUDE_DIR_Physics} ${SOURCE_CXX_INCLUDE_DIR_Terrain} ${SOURCE_CXX_INCLUDE_DIR_Graphics} ${SOURCE_CXX_INCLUDE_DIR_Audio} ${SOURCE_CXX_INCLUDE_DIR_Core} ${SOURCE_CXX_INCLUDE_DIR_Common} ${SOURCE_CXX_INCLUDE_DIR_Editor} ${SOURCE_CXX_INCLUDE_DIR_Input})
 
 
 

--- a/K.Engine.Common/include/Core/MeshData.hpp
+++ b/K.Engine.Common/include/Core/MeshData.hpp
@@ -1,0 +1,58 @@
+#pragma once
+#include <vector>
+#include <cstdint>
+#include <glm.hpp>
+
+namespace KDot
+{
+    // CPU-side, backend-agnostic mesh. Subsystems that generate geometry
+    // (terrain, future model loaders, debug shapes) fill these out without any
+    // graphics-API dependency; the renderer uploads them to a GPU buffer.
+    //
+    // IMPORTANT: MeshVertex intentionally mirrors KDot::Vertex in the renderer
+    // field-for-field so the renderer can upload the array directly. Keep the
+    // two layouts in sync.
+    struct MeshVertex
+    {
+        glm::vec3 position{0.0f};
+        glm::vec4 color{1.0f};
+        glm::vec3 normal{0.0f, 1.0f, 0.0f};
+        glm::vec2 texCoord{0.0f};
+        int       texIndex = 0;
+    };
+
+    struct MeshData
+    {
+        std::vector<MeshVertex>     vertices;
+        std::vector<std::uint32_t>  indices;
+
+        void Clear() { vertices.clear(); indices.clear(); }
+        bool Empty() const { return indices.empty(); }
+        std::size_t TriangleCount() const { return indices.size() / 3; }
+
+        // Recompute smooth per-vertex normals from the index buffer (area-weighted).
+        void RecalculateNormals()
+        {
+            for (auto& v : vertices)
+                v.normal = glm::vec3(0.0f);
+
+            for (std::size_t i = 0; i + 2 < indices.size(); i += 3)
+            {
+                const std::uint32_t a = indices[i];
+                const std::uint32_t b = indices[i + 1];
+                const std::uint32_t c = indices[i + 2];
+                const glm::vec3 n = glm::cross(vertices[b].position - vertices[a].position,
+                                               vertices[c].position - vertices[a].position);
+                vertices[a].normal += n; // unnormalized cross == area-weighted
+                vertices[b].normal += n;
+                vertices[c].normal += n;
+            }
+
+            for (auto& v : vertices)
+            {
+                const float len = glm::length(v.normal);
+                v.normal = (len > 1e-8f) ? v.normal / len : glm::vec3(0.0f, 1.0f, 0.0f);
+            }
+        }
+    };
+}

--- a/K.Engine.Common/include/Core/Noise.hpp
+++ b/K.Engine.Common/include/Core/Noise.hpp
@@ -1,0 +1,67 @@
+#pragma once
+#include <glm.hpp>
+#include <gtc/noise.hpp>
+#include <algorithm>
+#include <cmath>
+
+namespace KDot
+{
+    // Fractal noise helpers layered on GLM's gradient noise. These are pure
+    // functions of position + parameters, so terrain generation is fully
+    // deterministic and reproducible from a seed.
+    struct NoiseParams
+    {
+        int   octaves     = 5;
+        float frequency   = 0.0035f; // base frequency (world units^-1)
+        float lacunarity  = 2.0f;    // frequency multiplier per octave
+        float gain        = 0.5f;    // amplitude multiplier per octave
+        float amplitude   = 1.0f;    // overall amplitude
+        glm::vec2 offset  = {0.0f, 0.0f}; // seed offset in noise space
+    };
+
+    namespace Noise
+    {
+        // Classic fractal Brownian motion. Returns roughly [-amplitude, amplitude].
+        inline float FBM(glm::vec2 p, const NoiseParams& np)
+        {
+            p = (p + np.offset) * np.frequency;
+            float sum = 0.0f, amp = 1.0f, norm = 0.0f;
+            for (int i = 0; i < np.octaves; ++i)
+            {
+                sum  += amp * glm::simplex(p);
+                norm += amp;
+                p    *= np.lacunarity;
+                amp  *= np.gain;
+            }
+            return (norm > 0.0f ? sum / norm : 0.0f) * np.amplitude;
+        }
+
+        // Ridged multifractal - sharp ridges, good for mountains/canyons.
+        // Returns roughly [0, amplitude].
+        inline float Ridged(glm::vec2 p, const NoiseParams& np)
+        {
+            p = (p + np.offset) * np.frequency;
+            float sum = 0.0f, amp = 1.0f, norm = 0.0f;
+            for (int i = 0; i < np.octaves; ++i)
+            {
+                float n = 1.0f - std::fabs(glm::simplex(p));
+                n *= n; // sharpen ridges
+                sum  += amp * n;
+                norm += amp;
+                p    *= np.lacunarity;
+                amp  *= np.gain;
+            }
+            return (norm > 0.0f ? sum / norm : 0.0f) * np.amplitude;
+        }
+
+        // Domain-warped FBM: feed the position through noise before sampling it
+        // again, producing swirling, organic terrain instead of uniform hills.
+        inline float Warped(glm::vec2 p, const NoiseParams& np, float warpStrength = 40.0f)
+        {
+            const glm::vec2 q{
+                FBM(p + glm::vec2(0.0f, 0.0f), np),
+                FBM(p + glm::vec2(5.2f, 1.3f), np)};
+            return FBM(p + warpStrength * q, np);
+        }
+    }
+}

--- a/K.Engine.Common/include/Core/QualitySettings.hpp
+++ b/K.Engine.Common/include/Core/QualitySettings.hpp
@@ -1,0 +1,129 @@
+#pragma once
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace KDot
+{
+    // -------------------------------------------------------------------------
+    // QualitySettings
+    //
+    //  The single "fidelity dial" for the engine. Every subsystem (terrain LOD,
+    //  render distance, lighting, shadows, texture sampling) derives its
+    //  parameters from one master value, m_Fidelity, in the range [0, 1].
+    //
+    //      0.0  -> Iruna Online tier  (tiny draw distance, coarse meshes)
+    //      1.0  -> Elden Ring tier    (huge draw distance, dense meshes, shadows)
+    //
+    //  The project default is 0.65, the target look for K.Engine. Changing the
+    //  dial at runtime recomputes every derived field, so a settings menu only
+    //  ever has to touch SetFidelity()/ApplyTier().
+    // -------------------------------------------------------------------------
+
+    enum class QualityTier : int
+    {
+        Iruna   = 0, // 0.00 - mobile MMO baseline
+        Low     = 1, // 0.25
+        Medium  = 2, // 0.50
+        KEngine = 3, // 0.65 - the project's target fidelity
+        High    = 4, // 0.80
+        Elden   = 5  // 1.00 - reference ceiling
+    };
+
+    struct QualitySettings
+    {
+        // ---- Derived parameters (read by other subsystems) ------------------
+        float renderDistance        = 1350.0f; // far plane / world cull distance (world units)
+        int   maxLODLevels          = 4;       // number of discrete LOD steps (LOD0..LODn-1)
+        float lodDistanceStep       = 220.0f;  // world distance between successive LOD bands
+        float lodBias               = 1.0f;    // global multiplier on LOD band distances (>1 keeps detail longer)
+        int   terrainChunkEdgeVerts = 65;      // vertices per chunk edge at LOD0 (always 2^n + 1)
+        bool  shadowsEnabled        = true;
+        int   shadowMapSize         = 2048;    // 0 == disabled
+        int   maxLights             = 24;
+        int   anisotropy            = 8;       // texture anisotropic filtering samples
+        float textureLodBias        = -0.15f;  // negative == sharper sampling
+        int   msaaSamples           = 4;       // 1 == off
+
+        // ---- Master dial ----------------------------------------------------
+        static QualitySettings& Get()
+        {
+            static QualitySettings s_Instance = [] {
+                QualitySettings q;
+                q.SetFidelity(0.65f); // K.Engine target
+                return q;
+            }();
+            return s_Instance;
+        }
+
+        float Fidelity() const { return m_Fidelity; }
+
+        // Set the master fidelity dial and recompute every derived field.
+        void SetFidelity(float fidelity)
+        {
+            m_Fidelity = std::clamp(fidelity, 0.0f, 1.0f);
+            const float f = m_Fidelity;
+
+            renderDistance  = Lerp(120.0f, 2600.0f, f);
+            maxLODLevels    = static_cast<int>(std::lround(Lerp(2.0f, 6.0f, f)));
+            lodDistanceStep = Lerp(70.0f, 420.0f, f);
+            lodBias         = Lerp(0.8f, 1.4f, f);
+
+            // Chunk density snaps to 2^n + 1 so neighbouring LODs share edge verts.
+            terrainChunkEdgeVerts = SnapPow2Plus1(static_cast<int>(Lerp(17.0f, 129.0f, f)));
+
+            shadowsEnabled = f > 0.2f;
+            shadowMapSize  = shadowsEnabled ? SnapPow2(static_cast<int>(Lerp(512.0f, 4096.0f, f))) : 0;
+
+            maxLights      = static_cast<int>(std::lround(Lerp(4.0f, 64.0f, f)));
+            anisotropy     = SnapPow2(static_cast<int>(Lerp(1.0f, 16.0f, f)));
+            textureLodBias = Lerp(0.5f, -0.5f, f);
+            msaaSamples    = SnapPow2(static_cast<int>(Lerp(1.0f, 8.0f, f)));
+        }
+
+        // Convenience presets that map onto the same continuous dial.
+        void ApplyTier(QualityTier tier)
+        {
+            switch (tier)
+            {
+                case QualityTier::Iruna:   SetFidelity(0.00f); break;
+                case QualityTier::Low:     SetFidelity(0.25f); break;
+                case QualityTier::Medium:  SetFidelity(0.50f); break;
+                case QualityTier::KEngine: SetFidelity(0.65f); break;
+                case QualityTier::High:    SetFidelity(0.80f); break;
+                case QualityTier::Elden:   SetFidelity(1.00f); break;
+            }
+        }
+
+        // Pick a LOD index from a camera-space distance. 0 == highest detail.
+        // maxLevels lets callers cap against the resolution they actually have.
+        int SelectLOD(float distance, int maxLevels) const
+        {
+            const int levels = std::max(1, std::min(maxLevels, maxLODLevels));
+            const float band = std::max(1.0f, lodDistanceStep * lodBias);
+            int lod = static_cast<int>(distance / band);
+            return std::clamp(lod, 0, levels - 1);
+        }
+
+    private:
+        float m_Fidelity = 0.65f;
+
+        static float Lerp(float a, float b, float t) { return a + (b - a) * t; }
+
+        // Round up to the nearest power of two (clamped to >= 1).
+        static int SnapPow2(int v)
+        {
+            if (v <= 1) return 1;
+            int p = 1;
+            while (p < v) p <<= 1;
+            // Snap to whichever power of two is closer.
+            return (p - v) < (v - (p >> 1)) ? p : (p >> 1);
+        }
+
+        // Snap to the nearest value of the form 2^n + 1 (17, 33, 65, 129 ...).
+        static int SnapPow2Plus1(int v)
+        {
+            return SnapPow2(std::max(2, v - 1)) + 1;
+        }
+    };
+}

--- a/K.Engine.Common/include/Core/Transform.hpp
+++ b/K.Engine.Common/include/Core/Transform.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include <glm.hpp>
+#include <gtc/quaternion.hpp>
+#include <gtc/matrix_transform.hpp>
+
+namespace KDot
+{
+    // A standard TRS transform component. Rotation is a quaternion to avoid
+    // gimbal lock; helpers are provided for the common Euler-degrees case.
+    struct Transform
+    {
+        glm::vec3 position{0.0f};
+        glm::quat rotation{1.0f, 0.0f, 0.0f, 0.0f}; // identity (w,x,y,z)
+        glm::vec3 scale{1.0f};
+
+        Transform() = default;
+        explicit Transform(const glm::vec3& pos) : position(pos) {}
+        Transform(const glm::vec3& pos, const glm::quat& rot, const glm::vec3& scl)
+            : position(pos), rotation(rot), scale(scl) {}
+
+        glm::mat4 Matrix() const
+        {
+            glm::mat4 m = glm::translate(glm::mat4(1.0f), position);
+            m *= glm::mat4_cast(rotation);
+            m = glm::scale(m, scale);
+            return m;
+        }
+
+        glm::vec3 Forward() const { return rotation * glm::vec3(0.0f, 0.0f, -1.0f); }
+        glm::vec3 Right()   const { return rotation * glm::vec3(1.0f, 0.0f, 0.0f); }
+        glm::vec3 Up()      const { return rotation * glm::vec3(0.0f, 1.0f, 0.0f); }
+
+        void SetEulerDegrees(const glm::vec3& eulerDeg)
+        {
+            rotation = glm::quat(glm::radians(eulerDeg));
+        }
+    };
+}

--- a/K.Engine.Common/include/EntitityComponentSystem/ECS.hpp
+++ b/K.Engine.Common/include/EntitityComponentSystem/ECS.hpp
@@ -1,0 +1,242 @@
+#pragma once
+// -----------------------------------------------------------------------------
+// K.Engine ECS
+//
+//  A small, dependency-free entity-component-system built on sparse sets, in the
+//  spirit of EnTT but trimmed to what the engine needs. Components are stored in
+//  packed (dense) arrays for cache-friendly iteration; entities are 32-bit
+//  handles carrying an index + version so stale handles are detected after a
+//  slot is recycled.
+//
+//  Usage:
+//      KDot::ecs::Registry reg;
+//      auto e = reg.Create();
+//      reg.Emplace<Transform>(e, position);
+//      reg.View<Transform, Rigidbody>([](auto entity, Transform& t, Rigidbody& rb){ ... });
+//      reg.Destroy(e);
+//
+//  Note: do not Create/Destroy entities or add/remove the iterated component
+//  type *during* a View() over that type (swap-remove invalidates iteration).
+// -----------------------------------------------------------------------------
+#include <cstdint>
+#include <vector>
+#include <memory>
+#include <typeindex>
+#include <unordered_map>
+#include <utility>
+
+namespace KDot
+{
+    namespace ecs
+    {
+        using Entity        = std::uint32_t;
+        using EntityIndex   = std::uint32_t;
+        using EntityVersion = std::uint32_t;
+
+        constexpr std::uint32_t kIndexBits   = 20;                       // up to ~1M live entities
+        constexpr std::uint32_t kIndexMask   = (1u << kIndexBits) - 1u;
+        constexpr std::uint32_t kVersionMask = (1u << (32 - kIndexBits)) - 1u;
+        constexpr Entity        kNull        = ~Entity(0);
+
+        constexpr EntityIndex   IndexOf(Entity e)   { return e & kIndexMask; }
+        constexpr EntityVersion VersionOf(Entity e) { return (e >> kIndexBits) & kVersionMask; }
+        constexpr Entity        Make(EntityIndex i, EntityVersion v)
+        {
+            return (i & kIndexMask) | ((v & kVersionMask) << kIndexBits);
+        }
+
+        // ---------------------------------------------------------------------
+        // Component storage
+        // ---------------------------------------------------------------------
+        struct IPool
+        {
+            virtual ~IPool() = default;
+            virtual bool Remove(EntityIndex idx) = 0;
+            virtual bool Has(EntityIndex idx) const = 0;
+        };
+
+        template <typename T>
+        class Pool final : public IPool
+        {
+        public:
+            bool Has(EntityIndex idx) const override
+            {
+                return idx < m_Sparse.size() && m_Sparse[idx] != kTomb;
+            }
+
+            T& Get(EntityIndex idx) { return m_Dense[m_Sparse[idx]]; }
+            const T& Get(EntityIndex idx) const { return m_Dense[m_Sparse[idx]]; }
+
+            template <typename... Args>
+            T& Emplace(EntityIndex idx, Args&&... args)
+            {
+                if (idx >= m_Sparse.size())
+                    m_Sparse.resize(idx + 1, kTomb);
+
+                if (m_Sparse[idx] != kTomb) // replace existing component
+                {
+                    m_Dense[m_Sparse[idx]] = T{std::forward<Args>(args)...};
+                    return m_Dense[m_Sparse[idx]];
+                }
+
+                m_Sparse[idx] = static_cast<std::uint32_t>(m_Dense.size());
+                m_Owners.push_back(idx);
+                m_Dense.emplace_back(std::forward<Args>(args)...);
+                return m_Dense.back();
+            }
+
+            bool Remove(EntityIndex idx) override
+            {
+                if (!Has(idx))
+                    return false;
+
+                const std::uint32_t slot = m_Sparse[idx];
+                const std::uint32_t last = static_cast<std::uint32_t>(m_Dense.size()) - 1;
+
+                m_Dense[slot]  = std::move(m_Dense[last]);   // swap-remove keeps the array packed
+                m_Owners[slot] = m_Owners[last];
+                m_Sparse[m_Owners[slot]] = slot;
+
+                m_Dense.pop_back();
+                m_Owners.pop_back();
+                m_Sparse[idx] = kTomb;
+                return true;
+            }
+
+            std::vector<T>&           Data()    { return m_Dense; }
+            std::vector<EntityIndex>& Owners()  { return m_Owners; }
+            std::size_t               Size() const { return m_Dense.size(); }
+
+        private:
+            static constexpr std::uint32_t kTomb = ~std::uint32_t(0);
+            std::vector<std::uint32_t> m_Sparse; // entity index -> dense slot
+            std::vector<EntityIndex>   m_Owners; // dense slot   -> entity index
+            std::vector<T>             m_Dense;  // packed components
+        };
+
+        // ---------------------------------------------------------------------
+        // Registry
+        // ---------------------------------------------------------------------
+        class Registry
+        {
+        public:
+            Entity Create()
+            {
+                if (!m_Free.empty())
+                {
+                    const EntityIndex idx = m_Free.back();
+                    m_Free.pop_back();
+                    return Make(idx, m_Versions[idx]);
+                }
+                const EntityIndex idx = static_cast<EntityIndex>(m_Versions.size());
+                m_Versions.push_back(0);
+                return Make(idx, 0);
+            }
+
+            // A handle is valid only while its version still matches the slot's
+            // version. Destroy() bumps the slot version, so a freed slot can
+            // never match an outstanding handle -> no separate "alive" bitset.
+            bool Valid(Entity e) const
+            {
+                const EntityIndex idx = IndexOf(e);
+                return idx < m_Versions.size()
+                    && (m_Versions[idx] & kVersionMask) == VersionOf(e);
+            }
+
+            void Destroy(Entity e)
+            {
+                if (!Valid(e))
+                    return;
+                const EntityIndex idx = IndexOf(e);
+                for (auto& kv : m_Pools)
+                    kv.second->Remove(idx);
+                m_Versions[idx] = (m_Versions[idx] + 1) & kVersionMask; // invalidate stale handles
+                m_Free.push_back(idx);
+            }
+
+            template <typename T, typename... Args>
+            T& Emplace(Entity e, Args&&... args)
+            {
+                return Assure<T>().Emplace(IndexOf(e), std::forward<Args>(args)...);
+            }
+
+            template <typename T>
+            bool Has(Entity e) const
+            {
+                const Pool<T>* p = GetPool<T>();
+                return p && p->Has(IndexOf(e));
+            }
+
+            template <typename T>
+            T& Get(Entity e) { return Assure<T>().Get(IndexOf(e)); }
+
+            template <typename T>
+            T* TryGet(Entity e)
+            {
+                Pool<T>* p = GetPool<T>();
+                return (p && p->Has(IndexOf(e))) ? &p->Get(IndexOf(e)) : nullptr;
+            }
+
+            template <typename T>
+            void Remove(Entity e)
+            {
+                if (Pool<T>* p = GetPool<T>())
+                    p->Remove(IndexOf(e));
+            }
+
+            // Iterate every entity owning all of <T, Others...>.
+            // fn signature: void(Entity, T&, Others&...)
+            template <typename T, typename... Others, typename Fn>
+            void View(Fn&& fn)
+            {
+                Pool<T>* base = GetPool<T>();
+                if (!base)
+                    return;
+
+                std::vector<EntityIndex>& owners = base->Owners();
+                for (std::size_t i = 0; i < owners.size(); ++i)
+                {
+                    const EntityIndex idx = owners[i];
+                    if ((HasIdx<Others>(idx) && ...))
+                        fn(Make(idx, m_Versions[idx]), base->Get(idx), GetPool<Others>()->Get(idx)...);
+                }
+            }
+
+            std::size_t AliveCount() const { return m_Versions.size() - m_Free.size(); }
+
+        private:
+            template <typename T>
+            Pool<T>& Assure()
+            {
+                const std::type_index key(typeid(T));
+                auto it = m_Pools.find(key);
+                if (it == m_Pools.end())
+                {
+                    auto pool = std::make_unique<Pool<T>>();
+                    Pool<T>& ref = *pool;
+                    m_Pools.emplace(key, std::move(pool));
+                    return ref;
+                }
+                return *static_cast<Pool<T>*>(it->second.get());
+            }
+
+            template <typename T>
+            Pool<T>* GetPool() const
+            {
+                auto it = m_Pools.find(std::type_index(typeid(T)));
+                return it == m_Pools.end() ? nullptr : static_cast<Pool<T>*>(it->second.get());
+            }
+
+            template <typename T>
+            bool HasIdx(EntityIndex idx) const
+            {
+                const Pool<T>* p = GetPool<T>();
+                return p && p->Has(idx);
+            }
+
+            std::vector<EntityVersion> m_Versions;
+            std::vector<EntityIndex>   m_Free;
+            std::unordered_map<std::type_index, std::unique_ptr<IPool>> m_Pools;
+        };
+    } // namespace ecs
+} // namespace KDot

--- a/K.Engine.Common/src/EntityComponentSystem/ECS.cpp
+++ b/K.Engine.Common/src/EntityComponentSystem/ECS.cpp
@@ -1,0 +1,13 @@
+// The ECS is a header-only template library (see ECS.hpp). This translation
+// unit exists so the build globs at least one source file for the module and so
+// the header is compiled stand-alone, catching errors early.
+#include "EntitityComponentSystem/ECS.hpp"
+
+namespace KDot
+{
+    namespace ecs
+    {
+        static_assert(IndexOf(Make(123u, 7u)) == 123u, "ECS entity index packing is broken");
+        static_assert(VersionOf(Make(123u, 7u)) == 7u, "ECS entity version packing is broken");
+    }
+}

--- a/K.Engine.Core/src/main.cpp
+++ b/K.Engine.Core/src/main.cpp
@@ -2,103 +2,145 @@
 
 #include "imgui.h"      // External library, C++ ui library
 #include "imgui_internal.h"
-#include "Renderer.hpp" // Created by me; Used to render a static triangle to a frame buffer and display within a window
+#include "Renderer.hpp" // Renders geometry into a frame buffer shown in the viewport
+
+#include <Terrain.hpp>
+#include <PhysicsWorld.hpp>
+#include <EntitityComponentSystem/ECS.hpp>
+#include <Core/Transform.hpp>
+#include <Core/QualitySettings.hpp>
+#include <algorithm>
+
 using namespace std;
 
 namespace KDot
 {
-
-    class Tetris : public Layer
+    // -------------------------------------------------------------------------
+    // WorldLayer
+    //
+    //  Demo bringing the new foundation together: a procedurally generated,
+    //  LOD'd terrain (driven by the fidelity dial), a physics body that falls
+    //  and settles on the surface via the ECS + PhysicsWorld, and an editor
+    //  panel that sculpts the terrain and scrubs fidelity at runtime.
+    // -------------------------------------------------------------------------
+    class WorldLayer : public Layer
     {
         Renderer m_Renderer;
+        Camera   m_Camera;
+        Terrain  m_Terrain;
+        PhysicsWorld   m_Physics;
+        ecs::Registry  m_Registry;
+        ecs::Entity    m_Ball = ecs::kNull;
+
+        ImVec2 viewportSize = ImVec2(0.0f, 0.0f);
+        bool   first = true;
+
+        // Editor state
+        float m_Fidelity      = 0.65f;
+        float m_BrushRadius   = 24.0f;
+        float m_BrushStrength = 12.0f;
+        int   m_Seed          = 1337;
 
     public:
-        float GRAVITY = -0.075f;
-        glm::vec2 m_Position = {0.0f, 0.0f};
-        ImVec2 viewportSize = ImVec2(0.0f, 0.0f);
-
-        double cumulatedTime = 0.0;
-        double interval = 1000.0;
-        float angle = 0.0f;
-        Camera m_Camera = Camera();
-        bool first = true;
-        std::vector<std::vector<int>> Cells;
-        bool resize = false;
-        Tetris() : Layer("Test Layer")
+        WorldLayer() : Layer("World")
         {
-            
             m_Renderer.Compile();
             m_Renderer.GenerateFrameBuffer();
 
-            //m_Shapes = new Shape[100];
-            
+            QualitySettings::Get().SetFidelity(m_Fidelity);
+            RegenerateTerrain();
+
+            // Physics walks on the terrain heightfield.
+            m_Physics.sampleTerrainHeight = [this](float x, float z) { return m_Terrain.HeightAt(x, z); };
+            m_Physics.sampleTerrainNormal = [this](float x, float z) { return m_Terrain.NormalAt(x, z); };
+
+            // Fly camera looking out over the terrain.
+            m_Camera = Camera(glm::vec3(0.0f, 140.0f, 280.0f), glm::vec3(0.0f, 1.0f, 0.0f), -90.0f, -22.0f);
+
+            SpawnBall();
         }
-        ~Tetris()
+
+        ~WorldLayer() {}
+
+        void RegenerateTerrain()
         {
+            const int edge  = QualitySettings::Get().terrainChunkEdgeVerts;
+            const int cells  = edge - 1;
+            const float cell = 2.0f;
+
+            TerrainConfig cfg;
+            cfg.chunksX = 6;
+            cfg.chunksZ = 6;
+            cfg.cellSize = cell;
+            cfg.heightScale = 85.0f;
+            cfg.useWarp = true;
+            cfg.seed = static_cast<std::uint32_t>(m_Seed);
+            cfg.chunk.chunkEdge = edge;
+
+            const float spanX = cfg.chunksX * cells * cell;
+            const float spanZ = cfg.chunksZ * cells * cell;
+            cfg.origin = glm::vec3(-spanX * 0.5f, 0.0f, -spanZ * 0.5f); // centre the world at the origin
+
+            m_Terrain.Generate(cfg);
         }
+
+        void SpawnBall()
+        {
+            if (m_Registry.Valid(m_Ball))
+                m_Registry.Destroy(m_Ball);
+
+            m_Ball = m_Registry.Create();
+            const float gy = m_Terrain.HeightAt(0.0f, 0.0f) + 90.0f;
+            m_Registry.Emplace<Transform>(m_Ball, glm::vec3(0.0f, gy, 0.0f));
+            Rigidbody& rb = m_Registry.Emplace<Rigidbody>(m_Ball);
+            rb.SetMass(2.0f);
+            rb.restitution = 0.45f;
+            rb.friction = 0.4f;
+            m_Registry.Emplace<Collider>(m_Ball, Collider::MakeSphere(3.0f));
+        }
+
         virtual void Update(const double deltaTime) override
         {
-            // Delta time is the time between frames in milliseconds
-            if (resize)
-            {
-                // m_Renderer.RescaleFrameBuffer(viewportSize.x, viewportSize.y);
-                resize = false;
-            }
-            cumulatedTime += deltaTime;
-            if (cumulatedTime >= interval)
-            {
-                Interval();
-                cumulatedTime = 0.0;
-            }
-            m_Renderer.BindFrameBuffer();
-            glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
-            glEnable(GL_DEPTH_TEST);  
-            glEnable(GL_CULL_FACE); 
-            glCullFace(GL_BACK);
-            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-            m_Camera.Update(deltaTime);
-            m_Renderer.BeginStream(m_Camera);
-            // Render gizmos
-            Draw(deltaTime);
-            m_Renderer.EndStream();
+            float dt = static_cast<float>(deltaTime) / 1000.0f; // ms -> seconds
+            dt = std::min(dt, 0.033f);                          // clamp huge first-frame steps
 
+            m_Camera.Update(deltaTime);
+            m_Terrain.Update(m_Camera.m_Position); // LOD selection + rebuild dirty chunks
+            m_Physics.Step(m_Registry, dt);
+
+            m_Renderer.BindFrameBuffer();
+            glViewport(0, 0, 2560, 1440); // match the fixed framebuffer (ImGui resets the viewport each frame)
+            glClearColor(0.45f, 0.62f, 0.85f, 1.0f); // sky
+            glEnable(GL_DEPTH_TEST);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+            m_Renderer.BeginStream(m_Camera);
+
+            for (const TerrainChunk& chunk : m_Terrain.Chunks())
+                m_Renderer.DrawMesh(chunk.Mesh());
+
+            if (Transform* t = m_Registry.TryGet<Transform>(m_Ball))
+                m_Renderer.DrawCube(t->position, glm::vec3(6.0f), glm::vec4(0.9f, 0.3f, 0.2f, 1.0f), 0.0f);
+
+            m_Renderer.EndStream();
             m_Renderer.UnbindFrameBuffer();
         }
+
         virtual void OnEvent(Event &e) override
         {
             EventDispatcher dispatcher(e);
-            dispatcher.Dispatch<KeyPressedEvent>(BindEvent(Tetris::OnKeyPressed));
-            // Simply runs the OnKeyPressed function if the event is a KeyPressedEvent
-            //  printf("TestLayer::Event\n");
+            dispatcher.Dispatch<KeyPressedEvent>(BindEvent(WorldLayer::OnKeyPressed));
         }
+
         bool OnKeyPressed(KeyPressedEvent &e)
         {
-            
+            if (e.GetKeyCode() == KDot::Key::R)
+                SpawnBall(); // R re-drops the ball
             return false;
         }
-        void Draw(const double delta) // Repeatedly streams vertex data for a cube into the renderer, takes in a delta time value to animate the cubes
+
+        virtual void Render() override
         {
-            angle += 0.0f;
-            if (angle > 360.0f)
-                angle -= 360.0f;
-            for (int x = 0; x < 10; x++) {
-                for (int y= 0; y < 10; y++) {
-                    for (int z = 0; z < 10; z++) {
-                        m_Renderer.DrawCube({ (float)x* 5 - 0.5f, (float)y * 5, (float)z * 5.0f}, {0.25f, 0.25f, 0.25f}, {0.05f, 0.5f, 0.4f, 1.0f}, angle);
-                    }
-                }
-            }
-               
-            
-        }
-        void Interval()
-        {
-            
-        }
-        
-        virtual void Render() override //Renders UI to the screen, and creates a window to display the rendered data using a frame buffer
-        {
-            static bool dockspace = true;
             ImGuiWindowFlags window_flags = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking;
             ImGuiViewport *viewport = ImGui::GetMainViewport();
             ImGui::SetNextWindowPos(viewport->Pos);
@@ -112,84 +154,99 @@ namespace KDot
             if (dockspace_flags & ImGuiDockNodeFlags_PassthruCentralNode)
                 window_flags |= ImGuiWindowFlags_NoBackground;
             ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-            
+
             ImGui::Begin("K.Engine", nullptr, window_flags);
             ImGui::PopStyleVar();
-            ImGui::PopStyleVar(2);      
+            ImGui::PopStyleVar(2);
             ImGuiIO &io = ImGui::GetIO();
-            ImGuiStyle &style = ImGui::GetStyle();
-            
+
             if (io.ConfigFlags & ImGuiConfigFlags_DockingEnable)
             {
                 ImGuiID dockspace_id = ImGui::GetID("Dockspace");
-                
                 ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), dockspace_flags);
-                if (first) {
+                if (first)
+                {
                     first = false;
-                    ImGui::DockBuilderRemoveNode(dockspace_id); // Clear out existing layout
+                    ImGui::DockBuilderRemoveNode(dockspace_id);
                     ImGui::DockBuilderAddNode(dockspace_id, dockspace_flags | ImGuiDockNodeFlags_DockSpace);
                     ImGui::DockBuilderSetNodePos(dockspace_id, viewport->Pos);
                     ImGui::DockBuilderSetNodeSize(dockspace_id, viewport->Size);
-                
-                    auto dock_id_left = ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Left, 0.8f, nullptr, &dockspace_id);
-                
 
+                    auto dock_id_left = ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Left, 0.78f, nullptr, &dockspace_id);
                     ImGui::DockBuilderDockWindow("Viewport", dock_id_left);
-                    ImGui::DockBuilderDockWindow("Stats", dockspace_id);
+                    ImGui::DockBuilderDockWindow("Inspector", dockspace_id);
                     ImGui::DockBuilderFinish(dockspace_id);
                 }
-                
-
             }
-            
+
             if (ImGui::BeginMenuBar())
             {
                 if (ImGui::BeginMenu("File"))
                 {
-                    if (ImGui::MenuItem("Open..", "Ctrl+O"))
-                    { /* Do stuff */
-                    }
-                    if (ImGui::MenuItem("New Project", "Ctrl+N"))
-                    { /* Do stuff */
-                    }
-                    if (ImGui::MenuItem("Save Project", "Ctrl+S"))
-                    { /* Do stuff */
-                    }
-                    if (ImGui::MenuItem("Save Project As..", "Ctrl+Shift+S"))
-                    { /* Do stuff */
-                    }
-                    if (ImGui::MenuItem("Close Project", "Ctrl+W"))
-                    { /* Do stuff */
-                    }
+                    if (ImGui::MenuItem("Open..", "Ctrl+O")) {}
+                    if (ImGui::MenuItem("New Project", "Ctrl+N")) {}
+                    if (ImGui::MenuItem("Save Project", "Ctrl+S")) {}
                     ImGui::EndMenu();
                 }
                 ImGui::EndMenuBar();
             }
-            
-            ImGui::Begin("Stats");
 
-            ImGui::Text("FPS: %f", ImGui::GetIO().Framerate);
-            ImGui::Text("Frame Time: %f", ImGui::GetIO().DeltaTime);
-            ImGui::Text("Mouse Position: %f, %f", ImGui::GetIO().MousePos.x, ImGui::GetIO().MousePos.y);
+            // ---- Inspector ----------------------------------------------------
+            ImGui::Begin("Inspector");
+
+            ImGui::Text("FPS: %.1f  (%.2f ms)", io.Framerate, io.DeltaTime * 1000.0f);
             ImGui::Text("Draw Calls: %d", m_Renderer.DrawCallCount);
-            ImGui::Text("Quads: %d", m_Renderer.QuadCount);
+            ImGui::Text("Triangles: %d", m_Renderer.Triangles);
+            ImGui::Separator();
+
+            QualitySettings& q = QualitySettings::Get();
+            ImGui::TextUnformatted("Fidelity (Iruna 0.0  <->  Elden 1.0)");
+            if (ImGui::SliderFloat("##fidelity", &m_Fidelity, 0.0f, 1.0f, "%.2f"))
+                q.SetFidelity(m_Fidelity); // live: changes LOD bands / render distance immediately
+            ImGui::Text("Render dist: %.0f   Chunk edge: %d", q.renderDistance, q.terrainChunkEdgeVerts);
+            ImGui::Text("Max LOD: %d   Shadows: %s", q.maxLODLevels, q.shadowsEnabled ? "on" : "off");
+
+            ImGui::Separator();
+            ImGui::Text("Terrain: %zu chunks, %zu tris", m_Terrain.Chunks().size(), m_Terrain.TriangleCount());
+            ImGui::InputInt("Seed", &m_Seed);
+            if (ImGui::Button("Regenerate"))
+                RegenerateTerrain(); // rebuilds with the new chunk density / seed
+
+            ImGui::Separator();
+            ImGui::TextUnformatted("Sculpt (at world origin)");
+            ImGui::SliderFloat("Radius", &m_BrushRadius, 2.0f, 80.0f, "%.0f");
+            ImGui::SliderFloat("Strength", &m_BrushStrength, 1.0f, 40.0f, "%.0f");
+            const glm::vec2 brushXZ(0.0f, 0.0f);
+            if (ImGui::Button("Raise"))   m_Terrain.Sculpt(brushXZ, m_BrushRadius, m_BrushStrength, SculptMode::Raise);
+            ImGui::SameLine();
+            if (ImGui::Button("Lower"))   m_Terrain.Sculpt(brushXZ, m_BrushRadius, m_BrushStrength, SculptMode::Lower);
+            ImGui::SameLine();
+            if (ImGui::Button("Smooth"))  m_Terrain.Sculpt(brushXZ, m_BrushRadius, m_BrushStrength, SculptMode::Smooth);
+            ImGui::SameLine();
+            if (ImGui::Button("Flatten")) m_Terrain.Sculpt(brushXZ, m_BrushRadius, m_BrushStrength, SculptMode::Flatten);
+
+            ImGui::Separator();
+            if (ImGui::Button("Drop ball (R)"))
+                SpawnBall();
+            if (Transform* t = m_Registry.TryGet<Transform>(m_Ball))
+            {
+                Rigidbody* rb = m_Registry.TryGet<Rigidbody>(m_Ball);
+                ImGui::Text("Ball y: %.1f  grounded: %s", t->position.y, (rb && rb->onGround) ? "yes" : "no");
+            }
+            ImGui::TextDisabled("WASD to fly the camera");
             ImGui::End();
+
+            // ---- Viewport -----------------------------------------------------
             ImGui::Begin("Viewport");
-            
             ImVec2 viewportPanelSize = ImGui::GetContentRegionAvail();
             viewportSize = viewportPanelSize;
-            resize = true;
-            
             ImGui::Image((void *)m_Renderer.GetFrameBufferTexture(), viewportPanelSize, ImVec2(0, 1), ImVec2(1, 0));
             ImGui::End();
-            
-            
+
             ImGui::End();
         }
 
-        virtual void PostRender() override
-        {
-        }
+        virtual void PostRender() override {}
     };
 
     class TestApp : public Application
@@ -197,17 +254,14 @@ namespace KDot
     public:
         TestApp(const Specification &spec) : Application(spec)
         {
-            PushLayer(new KDot::Tetris());
+            PushLayer(new KDot::WorldLayer());
         }
-        ~TestApp()
-        {
-        }
+        ~TestApp() {}
     };
 
     Application *CreateApplication()
     {
         Specification spec;
-        // Only contains width, height and title of the window
         spec.Width = 1920;
         spec.Height = 1080;
         spec.Title = "K.Engine";
@@ -218,7 +272,7 @@ namespace KDot
 int main()
 {
     auto app = KDot::CreateApplication();
-    app->Run(); // Custom implementation to run C++ within the browser using emscripten (compiles to webassembly/javascript)
+    app->Run(); // emscripten main loop (compiles to WebAssembly via Emscripten)
 
     return 0;
 }

--- a/K.Engine.Graphics/include/Renderer.hpp
+++ b/K.Engine.Graphics/include/Renderer.hpp
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <fstream>
 #include <Math/Vector.hpp>
+#include <Core/MeshData.hpp>
 #include <glm.hpp>
 #include <gtx/rotate_vector.hpp>
 #include <gtx/transform.hpp>
@@ -46,6 +47,11 @@ namespace KDot
         void EndStream();
         GLuint GetFrameBufferTexture() { return m_Texture; }
         void LoadTexture(const char *path);
+        // Draw an arbitrary indexed mesh (e.g. a terrain chunk) with the active
+        // camera. Uploaded immediately and drawn in its own draw call; this is
+        // separate from the quad/cube batch above. Call between BeginStream and
+        // EndStream so the view/projection match the rest of the frame.
+        void DrawMesh(const MeshData &mesh);
         void DrawCube(const glm::vec3 &position, const glm::vec3 &size, const glm::vec4 &color, float angle, unsigned int textureIndex = 0);
         void DrawQuad(const glm::vec2 &position, const glm::vec2 &size, const glm::vec4 &color, float rotation, const glm::vec2 &center);
         void DrawQuad(const glm::vec3 &position, const glm::vec2 &size, const glm::vec4 &color);
@@ -63,6 +69,7 @@ namespace KDot
         void SetVertexBufferData(const void *data, GLuint size);
         void AddVertexBuffer();
         void AddIndexBuffer();
+        void InitMeshBuffers();
         int m_CurrentTextureIndex = 0;
         glm::vec4 m_QuadVertexPositions[4];
         glm::vec4 m_CubeVertexPositions[8];
@@ -96,6 +103,11 @@ namespace KDot
         GLuint m_IndexBuffer;
         GLuint m_RenderBuffer;
         GLuint m_Texture;
+        // Dedicated buffers for DrawMesh (terrain / arbitrary indexed geometry).
+        GLuint m_MeshVAO = 0;
+        GLuint m_MeshVBO = 0;
+        GLuint m_MeshIBO = 0;
+        bool   m_MeshBuffersReady = false;
         glm::mat4 viewMatrix;
         float cameraZoom = 90.0f;
         float m_Height = 1280.0f;

--- a/K.Engine.Graphics/src/Renderer.cpp
+++ b/K.Engine.Graphics/src/Renderer.cpp
@@ -1,4 +1,6 @@
 #include <Renderer.hpp>
+#include <Core/QualitySettings.hpp>
+#include <cstddef>
 #define STB_IMAGE_IMPLEMENTATION
 #include <Image/stb_image.h>
 #define GLTextureMapIndex(x) (x == 0 ? GL_TEXTURE0 : x == 1 ? GL_TEXTURE1 : x == 2 ? GL_TEXTURE2 : x == 3 ? GL_TEXTURE3 : x == 4 ? GL_TEXTURE4 : x == 5 ? GL_TEXTURE5 : x == 6 ? GL_TEXTURE6 : x == 7 ? GL_TEXTURE7 : x == 8 ? GL_TEXTURE8 : x == 9 ? GL_TEXTURE9 : x == 10 ? GL_TEXTURE10 : x == 11 ? GL_TEXTURE11 : x == 12 ? GL_TEXTURE12 : x == 13 ? GL_TEXTURE13 : x == 14 ? GL_TEXTURE14 : x == 15 ? GL_TEXTURE15 : x == 16 ? GL_TEXTURE16 : x == 17 ? GL_TEXTURE17 : x == 18 ? GL_TEXTURE18 : x == 19 ? GL_TEXTURE19 : x == 20 ? GL_TEXTURE20 : x == 21 ? GL_TEXTURE21 : x == 22 ? GL_TEXTURE22 : x == 23 ? GL_TEXTURE23 : x == 24 ? GL_TEXTURE24 : x == 25 ? GL_TEXTURE25 : x == 26 ? GL_TEXTURE26 : x == 27 ? GL_TEXTURE27 : x == 28 ? GL_TEXTURE28 : x == 29 ? GL_TEXTURE29 : x == 30 ? GL_TEXTURE30 : x == 31 ? GL_TEXTURE31 : 0)
@@ -9,6 +11,12 @@ namespace KDot
     Renderer::~Renderer()
     {
         glDeleteProgram(m_ShaderProgram);
+        if (m_MeshBuffersReady)
+        {
+            glDeleteVertexArrays(1, &m_MeshVAO);
+            glDeleteBuffers(1, &m_MeshVBO);
+            glDeleteBuffers(1, &m_MeshIBO);
+        }
     }
     bool Renderer::InitShader(const char **ShaderSource, GLenum type)
     {
@@ -170,6 +178,55 @@ namespace KDot
         m_QuadIndexCount += 36;
         QuadCount+= 6;
     }
+    void Renderer::InitMeshBuffers()
+    {
+        glGenVertexArrays(1, &m_MeshVAO);
+        glGenBuffers(1, &m_MeshVBO);
+        glGenBuffers(1, &m_MeshIBO);
+
+        glBindVertexArray(m_MeshVAO);
+        glBindBuffer(GL_ARRAY_BUFFER, m_MeshVBO);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_MeshIBO);
+
+        glEnableVertexAttribArray(0);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(MeshVertex), (void *)offsetof(MeshVertex, position));
+        glEnableVertexAttribArray(1);
+        glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(MeshVertex), (void *)offsetof(MeshVertex, color));
+        glEnableVertexAttribArray(2);
+        glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(MeshVertex), (void *)offsetof(MeshVertex, normal));
+        glEnableVertexAttribArray(3);
+        glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, sizeof(MeshVertex), (void *)offsetof(MeshVertex, texCoord));
+        glEnableVertexAttribArray(4);
+        glVertexAttribIPointer(4, 1, GL_UNSIGNED_INT, sizeof(MeshVertex), (void *)offsetof(MeshVertex, texIndex));
+
+        m_MeshBuffersReady = true;
+    }
+    void Renderer::DrawMesh(const MeshData &mesh)
+    {
+        if (mesh.indices.empty())
+            return;
+        if (!m_MeshBuffersReady)
+            InitMeshBuffers();
+
+        glUseProgram(m_ShaderProgram);
+
+        // Far plane follows the fidelity dial so distant terrain isn't clipped.
+        const float farPlane = QualitySettings::Get().renderDistance;
+        glm::mat4 projection = glm::perspective(glm::radians(cameraZoom), 16.0f / 9.0f, 0.1f, farPlane);
+        glUniformMatrix4fv(u_ProjectionMat, 1, GL_FALSE, &projection[0][0]);
+        glUniformMatrix4fv(u_ViewMat, 1, GL_FALSE, &viewMatrix[0][0]);
+
+        glBindVertexArray(m_MeshVAO);
+        glBindBuffer(GL_ARRAY_BUFFER, m_MeshVBO);
+        glBufferData(GL_ARRAY_BUFFER, mesh.vertices.size() * sizeof(MeshVertex), mesh.vertices.data(), GL_DYNAMIC_DRAW);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_MeshIBO);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, mesh.indices.size() * sizeof(uint32_t), mesh.indices.data(), GL_DYNAMIC_DRAW);
+
+        glDrawElements(GL_TRIANGLES, (GLsizei)mesh.indices.size(), GL_UNSIGNED_INT, 0);
+
+        DrawCallCount++;
+        Triangles += (int)mesh.TriangleCount();
+    }
     void Renderer::NextBatch()
     {
         Flush();
@@ -186,7 +243,7 @@ namespace KDot
     }
     void Renderer::Flush()
     {
-        glm::mat4 projection = glm::perspective(glm::radians(cameraZoom), (float)16 / (float)9, 0.1f, 100.0f);
+        glm::mat4 projection = glm::perspective(glm::radians(cameraZoom), (float)16 / (float)9, 0.1f, QualitySettings::Get().renderDistance);
         glUniformMatrix4fv(u_ProjectionMat, 1, GL_FALSE, &projection[0][0]);
         glUniformMatrix4fv(u_ViewMat, 1, GL_FALSE, &viewMatrix[0][0]);
 

--- a/K.Engine.Physics/include/BoxCollider.hpp
+++ b/K.Engine.Physics/include/BoxCollider.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include <Shapes.hpp>
+#include <glm.hpp>
+
+namespace KDot
+{
+    // A convenience axis-aligned box collider. The physics solver works in terms
+    // of world-space AABBs; this helper turns a centre + half-extents (optionally
+    // offset and scaled by an owning transform) into one. Oriented boxes are a
+    // planned follow-up - for now rotation is ignored, which keeps the broad/
+    // narrow-phase cheap and is plenty for terrain-walking gameplay.
+    class BoxCollider
+    {
+    public:
+        BoxCollider() = default;
+        BoxCollider(const glm::vec3& halfExtents, const glm::vec3& center = glm::vec3(0.0f))
+            : m_HalfExtents(halfExtents), m_Center(center) {}
+
+        const glm::vec3& HalfExtents() const { return m_HalfExtents; }
+        const glm::vec3& Center()      const { return m_Center; }
+
+        void SetHalfExtents(const glm::vec3& h) { m_HalfExtents = h; }
+        void SetCenter(const glm::vec3& c)      { m_Center = c; }
+
+        // World-space bounds for a body located at worldPosition (with an
+        // optional non-uniform scale applied to the half-extents).
+        AABB WorldBounds(const glm::vec3& worldPosition,
+                         const glm::vec3& scale = glm::vec3(1.0f)) const
+        {
+            const glm::vec3 c = worldPosition + m_Center * scale;
+            return AABB::FromCenterHalf(c, m_HalfExtents * scale);
+        }
+
+    private:
+        glm::vec3 m_HalfExtents{0.5f};
+        glm::vec3 m_Center{0.0f};
+    };
+}

--- a/K.Engine.Physics/include/Collision.hpp
+++ b/K.Engine.Physics/include/Collision.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <Shapes.hpp>
+
+namespace KDot
+{
+    // Narrow-phase contact generation. Each function returns a Manifold whose
+    // normal points from A toward B with the minimum translation distance in
+    // 'penetration'. Resolve by pushing B along +normal / A along -normal.
+    namespace Collision
+    {
+        Manifold AABBvsAABB(const AABB& a, const AABB& b);
+        Manifold SphereVsSphere(const Sphere& a, const Sphere& b);
+
+        // Sphere (A) versus AABB (B).
+        Manifold SphereVsAABB(const Sphere& a, const AABB& b);
+    }
+}

--- a/K.Engine.Physics/include/PhysicsWorld.hpp
+++ b/K.Engine.Physics/include/PhysicsWorld.hpp
@@ -1,0 +1,65 @@
+#pragma once
+#include <Shapes.hpp>
+#include <Collision.hpp>
+#include <Rigidbody.hpp>
+#include <Core/Transform.hpp>
+#include <EntitityComponentSystem/ECS.hpp>
+
+#include <functional>
+#include <vector>
+#include <cstdint>
+
+namespace KDot
+{
+    // -------------------------------------------------------------------------
+    // PhysicsWorld
+    //
+    //  Steps every entity carrying Transform + Rigidbody + Collider components:
+    //    1. integrate forces (semi-implicit Euler)
+    //    2. resolve against the terrain heightfield (optional callback)
+    //    3. spatial-hash broadphase -> narrow-phase manifolds
+    //    4. impulse resolution + Baumgarte positional correction
+    //
+    //  It also answers world raycasts (colliders + terrain) for gameplay, AI,
+    //  and editor picking.
+    // -------------------------------------------------------------------------
+    class PhysicsWorld
+    {
+    public:
+        glm::vec3 gravity{0.0f, -9.81f, 0.0f};
+        int       solverIterations = 4;
+        float     broadphaseCellSize = 4.0f;
+        float     positionalCorrection = 0.2f; // Baumgarte factor [0,1]
+        float     penetrationSlop = 0.01f;
+
+        // Optional terrain hooks. When set, bodies collide with the heightfield.
+        std::function<float(float, float)>     sampleTerrainHeight;
+        std::function<glm::vec3(float, float)> sampleTerrainNormal;
+
+        void Step(ecs::Registry& registry, float dt);
+
+        // Nearest hit against all colliders (and terrain if a height hook is set).
+        RaycastHit Raycast(ecs::Registry& registry, const Ray& ray, float maxDistance = 1.0e30f);
+
+    private:
+        struct Proxy
+        {
+            ecs::Entity entity;
+            Transform*  transform;
+            Rigidbody*  body;
+            Collider*   collider;
+            AABB        bounds;
+        };
+
+        std::vector<Proxy> m_Proxies;
+
+        AABB   WorldAABB(const Transform& t, const Collider& c) const;
+        Sphere WorldSphere(const Transform& t, const Collider& c) const;
+        Manifold ComputeManifold(const Proxy& a, const Proxy& b) const;
+
+        void Integrate(float dt);
+        void ResolveTerrain();
+        void ResolveCollisions();
+        RaycastHit RaycastTerrain(const Ray& ray, float maxDistance) const;
+    };
+}

--- a/K.Engine.Physics/include/Rigidbody.hpp
+++ b/K.Engine.Physics/include/Rigidbody.hpp
@@ -1,0 +1,72 @@
+#pragma once
+#include <glm.hpp>
+
+namespace KDot
+{
+    // Dynamics state for an entity. Pair with a Transform (position) and a
+    // Collider component; PhysicsWorld integrates and resolves them.
+    struct Rigidbody
+    {
+        glm::vec3 velocity{0.0f};
+        glm::vec3 accumulatedForce{0.0f};
+
+        float mass          = 1.0f;
+        float invMass       = 1.0f;  // 0 => infinite mass (immovable)
+        float restitution   = 0.15f; // bounciness [0,1]
+        float friction      = 0.5f;  // tangential damping on contact [0,1]
+        float linearDamping = 0.02f; // per-second velocity bleed
+        bool  useGravity    = true;
+        bool  isStatic      = false; // static bodies never move
+        bool  onGround      = false; // set by the solver each step
+
+        void SetMass(float m)
+        {
+            mass = m;
+            invMass = (m > 0.0f && !isStatic) ? 1.0f / m : 0.0f;
+        }
+
+        void SetStatic(bool s)
+        {
+            isStatic = s;
+            invMass = (s || mass <= 0.0f) ? 0.0f : 1.0f / mass;
+        }
+
+        void ApplyForce(const glm::vec3& f)   { accumulatedForce += f; }
+        void ApplyImpulse(const glm::vec3& j) { velocity += j * invMass; }
+    };
+
+    enum class ColliderType
+    {
+        Box,
+        Sphere
+    };
+
+    // A single collider attached to an entity. Box uses halfExtents; Sphere uses
+    // radius. localOffset shifts the shape relative to the Transform position.
+    struct Collider
+    {
+        ColliderType type = ColliderType::Box;
+        glm::vec3    halfExtents{0.5f}; // Box
+        float        radius = 0.5f;     // Sphere
+        glm::vec3    localOffset{0.0f};
+        bool         isTrigger = false; // detect overlaps but don't resolve them
+
+        static Collider MakeBox(const glm::vec3& half, const glm::vec3& offset = glm::vec3(0.0f))
+        {
+            Collider c;
+            c.type = ColliderType::Box;
+            c.halfExtents = half;
+            c.localOffset = offset;
+            return c;
+        }
+
+        static Collider MakeSphere(float r, const glm::vec3& offset = glm::vec3(0.0f))
+        {
+            Collider c;
+            c.type = ColliderType::Sphere;
+            c.radius = r;
+            c.localOffset = offset;
+            return c;
+        }
+    };
+}

--- a/K.Engine.Physics/include/Shapes.hpp
+++ b/K.Engine.Physics/include/Shapes.hpp
@@ -1,0 +1,164 @@
+#pragma once
+#include <glm.hpp>
+#include <algorithm>
+#include <limits>
+#include <cmath>
+
+namespace KDot
+{
+    // -------------------------------------------------------------------------
+    // Geometric primitives + analytic ray tests. All header-only and free of
+    // any graphics-API dependency so they compile on every target.
+    // -------------------------------------------------------------------------
+
+    struct Ray
+    {
+        glm::vec3 origin{0.0f};
+        glm::vec3 direction{0.0f, 0.0f, -1.0f}; // expected to be normalized
+
+        glm::vec3 At(float t) const { return origin + direction * t; }
+    };
+
+    struct RaycastHit
+    {
+        bool      hit = false;
+        float     distance = 0.0f;
+        glm::vec3 point{0.0f};
+        glm::vec3 normal{0.0f};
+        std::uint32_t entity = ~0u; // filled in by PhysicsWorld queries
+    };
+
+    // Contact manifold; normal points from shape A toward shape B.
+    struct Manifold
+    {
+        bool      colliding = false;
+        glm::vec3 normal{0.0f};
+        float     penetration = 0.0f;
+    };
+
+    struct AABB
+    {
+        glm::vec3 min{0.0f};
+        glm::vec3 max{0.0f};
+
+        glm::vec3 Center()  const { return 0.5f * (min + max); }
+        glm::vec3 Extents() const { return 0.5f * (max - min); }
+        glm::vec3 Size()    const { return max - min; }
+
+        bool Contains(const glm::vec3& p) const
+        {
+            return p.x >= min.x && p.x <= max.x &&
+                   p.y >= min.y && p.y <= max.y &&
+                   p.z >= min.z && p.z <= max.z;
+        }
+
+        bool Intersects(const AABB& o) const
+        {
+            return min.x <= o.max.x && max.x >= o.min.x &&
+                   min.y <= o.max.y && max.y >= o.min.y &&
+                   min.z <= o.max.z && max.z >= o.min.z;
+        }
+
+        void Encapsulate(const glm::vec3& p)
+        {
+            min = glm::min(min, p);
+            max = glm::max(max, p);
+        }
+
+        glm::vec3 ClosestPoint(const glm::vec3& p) const
+        {
+            return glm::clamp(p, min, max);
+        }
+
+        static AABB FromCenterHalf(const glm::vec3& c, const glm::vec3& half)
+        {
+            return AABB{c - half, c + half};
+        }
+    };
+
+    struct Sphere
+    {
+        glm::vec3 center{0.0f};
+        float     radius = 0.5f;
+
+        AABB Bounds() const { return AABB::FromCenterHalf(center, glm::vec3(radius)); }
+    };
+
+    struct Plane
+    {
+        glm::vec3 normal{0.0f, 1.0f, 0.0f};
+        float     d = 0.0f; // plane: dot(normal, x) = d
+
+        float SignedDistance(const glm::vec3& p) const { return glm::dot(normal, p) - d; }
+    };
+
+    // ---- Ray intersection tests --------------------------------------------
+    inline RaycastHit RayVsAABB(const Ray& r, const AABB& box)
+    {
+        RaycastHit out;
+        float tmin = 0.0f;
+        float tmax = std::numeric_limits<float>::max();
+        int   hitAxis = 0;
+        float hitSign = -1.0f;
+
+        for (int a = 0; a < 3; ++a)
+        {
+            const float invD = 1.0f / r.direction[a];
+            float t0 = (box.min[a] - r.origin[a]) * invD;
+            float t1 = (box.max[a] - r.origin[a]) * invD;
+            float sign = -1.0f;
+            if (invD < 0.0f) { std::swap(t0, t1); sign = 1.0f; }
+            if (t0 > tmin) { tmin = t0; hitAxis = a; hitSign = sign; }
+            tmax = std::min(tmax, t1);
+            if (tmax < tmin)
+                return out; // miss
+        }
+
+        out.hit      = true;
+        out.distance = tmin;
+        out.point    = r.At(tmin);
+        out.normal   = glm::vec3(0.0f);
+        out.normal[hitAxis] = hitSign;
+        return out;
+    }
+
+    inline RaycastHit RayVsSphere(const Ray& r, const Sphere& s)
+    {
+        RaycastHit out;
+        const glm::vec3 oc = r.origin - s.center;
+        const float b = glm::dot(oc, r.direction);
+        const float c = glm::dot(oc, oc) - s.radius * s.radius;
+        const float disc = b * b - c;
+        if (disc < 0.0f)
+            return out;
+
+        const float sq = std::sqrt(disc);
+        float t = -b - sq;
+        if (t < 0.0f) t = -b + sq; // origin inside sphere -> far hit
+        if (t < 0.0f)
+            return out;
+
+        out.hit      = true;
+        out.distance = t;
+        out.point    = r.At(t);
+        out.normal   = glm::normalize(out.point - s.center);
+        return out;
+    }
+
+    inline RaycastHit RayVsPlane(const Ray& r, const Plane& p)
+    {
+        RaycastHit out;
+        const float denom = glm::dot(p.normal, r.direction);
+        if (std::fabs(denom) < 1e-6f)
+            return out; // parallel
+        const float t = (p.d - glm::dot(p.normal, r.origin)) / denom;
+        if (t < 0.0f)
+            return out;
+
+        out.hit      = true;
+        out.distance = t;
+        out.point    = r.At(t);
+        out.normal   = denom < 0.0f ? p.normal : -p.normal;
+        return out;
+    }
+}

--- a/K.Engine.Physics/src/BoxCollider.cpp
+++ b/K.Engine.Physics/src/BoxCollider.cpp
@@ -1,0 +1,4 @@
+// BoxCollider is currently header-only (see BoxCollider.hpp). This translation
+// unit keeps the Physics module's source glob non-empty and compiles the header
+// stand-alone so mistakes surface at build time.
+#include <BoxCollider.hpp>

--- a/K.Engine.Physics/src/Collision.cpp
+++ b/K.Engine.Physics/src/Collision.cpp
@@ -1,0 +1,88 @@
+#include <Collision.hpp>
+#include <algorithm>
+#include <cmath>
+
+namespace KDot
+{
+    namespace Collision
+    {
+        Manifold AABBvsAABB(const AABB& a, const AABB& b)
+        {
+            Manifold m;
+            if (!a.Intersects(b))
+                return m;
+
+            // Overlap along each axis; the smallest is the separating axis.
+            const glm::vec3 overlap{
+                std::min(a.max.x, b.max.x) - std::max(a.min.x, b.min.x),
+                std::min(a.max.y, b.max.y) - std::max(a.min.y, b.min.y),
+                std::min(a.max.z, b.max.z) - std::max(a.min.z, b.min.z)};
+
+            int axis = 0;
+            float minOverlap = overlap.x;
+            if (overlap.y < minOverlap) { minOverlap = overlap.y; axis = 1; }
+            if (overlap.z < minOverlap) { minOverlap = overlap.z; axis = 2; }
+
+            const glm::vec3 dir = b.Center() - a.Center();
+            m.colliding   = true;
+            m.penetration = minOverlap;
+            m.normal      = glm::vec3(0.0f);
+            m.normal[axis] = (dir[axis] < 0.0f) ? -1.0f : 1.0f;
+            return m;
+        }
+
+        Manifold SphereVsSphere(const Sphere& a, const Sphere& b)
+        {
+            Manifold m;
+            const glm::vec3 delta = b.center - a.center;
+            const float r = a.radius + b.radius;
+            const float dist2 = glm::dot(delta, delta);
+            if (dist2 >= r * r)
+                return m;
+
+            const float dist = std::sqrt(dist2);
+            m.colliding   = true;
+            m.penetration = r - dist;
+            m.normal      = dist > 1e-6f ? delta / dist : glm::vec3(0.0f, 1.0f, 0.0f);
+            return m;
+        }
+
+        Manifold SphereVsAABB(const Sphere& a, const AABB& b)
+        {
+            Manifold m;
+            const glm::vec3 closest = b.ClosestPoint(a.center);
+            const glm::vec3 delta   = closest - a.center;
+            const float dist2 = glm::dot(delta, delta);
+
+            if (dist2 > a.radius * a.radius)
+                return m;
+
+            if (dist2 > 1e-12f)
+            {
+                const float dist = std::sqrt(dist2);
+                m.colliding   = true;
+                m.penetration = a.radius - dist;
+                m.normal      = delta / dist; // from sphere (A) toward box (B)
+            }
+            else
+            {
+                // Sphere centre is inside the box: push out along the least-deep face.
+                const glm::vec3 c = b.Center();
+                const glm::vec3 e = b.Extents();
+                const glm::vec3 d = a.center - c;
+                const glm::vec3 face{e.x - std::fabs(d.x), e.y - std::fabs(d.y), e.z - std::fabs(d.z)};
+
+                int axis = 0;
+                float minFace = face.x;
+                if (face.y < minFace) { minFace = face.y; axis = 1; }
+                if (face.z < minFace) { minFace = face.z; axis = 2; }
+
+                m.colliding   = true;
+                m.penetration = a.radius + minFace;
+                m.normal      = glm::vec3(0.0f);
+                m.normal[axis] = (d[axis] < 0.0f) ? 1.0f : -1.0f; // toward box interior from sphere
+            }
+            return m;
+        }
+    }
+}

--- a/K.Engine.Physics/src/PhysicsWorld.cpp
+++ b/K.Engine.Physics/src/PhysicsWorld.cpp
@@ -1,0 +1,319 @@
+#include <PhysicsWorld.hpp>
+
+#include <unordered_map>
+#include <unordered_set>
+#include <algorithm>
+#include <cmath>
+
+namespace KDot
+{
+    namespace
+    {
+        // Pack a 3D integer cell coordinate into one 64-bit spatial-hash key.
+        inline std::int64_t CellKey(int x, int y, int z)
+        {
+            const std::int64_t X = static_cast<std::int64_t>(x) & 0x1FFFFF;
+            const std::int64_t Y = static_cast<std::int64_t>(y) & 0x1FFFFF;
+            const std::int64_t Z = static_cast<std::int64_t>(z) & 0x1FFFFF;
+            return X | (Y << 21) | (Z << 42);
+        }
+
+        inline std::uint64_t PairKey(int i, int j)
+        {
+            if (i > j) std::swap(i, j);
+            return (static_cast<std::uint64_t>(i) << 32) | static_cast<std::uint32_t>(j);
+        }
+    }
+
+    AABB PhysicsWorld::WorldAABB(const Transform& t, const Collider& c) const
+    {
+        if (c.type == ColliderType::Sphere)
+            return WorldSphere(t, c).Bounds();
+        const glm::vec3 center = t.position + c.localOffset * t.scale;
+        return AABB::FromCenterHalf(center, c.halfExtents * t.scale);
+    }
+
+    Sphere PhysicsWorld::WorldSphere(const Transform& t, const Collider& c) const
+    {
+        Sphere s;
+        s.center = t.position + c.localOffset * t.scale;
+        s.radius = c.radius * std::max(std::max(t.scale.x, t.scale.y), t.scale.z);
+        return s;
+    }
+
+    Manifold PhysicsWorld::ComputeManifold(const Proxy& a, const Proxy& b) const
+    {
+        const bool aBox = a.collider->type == ColliderType::Box;
+        const bool bBox = b.collider->type == ColliderType::Box;
+
+        if (aBox && bBox)
+            return Collision::AABBvsAABB(a.bounds, b.bounds);
+
+        if (!aBox && !bBox)
+            return Collision::SphereVsSphere(WorldSphere(*a.transform, *a.collider),
+                                             WorldSphere(*b.transform, *b.collider));
+
+        if (!aBox && bBox)
+            return Collision::SphereVsAABB(WorldSphere(*a.transform, *a.collider), b.bounds);
+
+        // box (a) vs sphere (b): compute sphere-vs-box, then flip the normal so
+        // it still points from A toward B.
+        Manifold m = Collision::SphereVsAABB(WorldSphere(*b.transform, *b.collider), a.bounds);
+        m.normal = -m.normal;
+        return m;
+    }
+
+    void PhysicsWorld::Step(ecs::Registry& registry, float dt)
+    {
+        if (dt <= 0.0f)
+            return;
+
+        m_Proxies.clear();
+        registry.View<Transform, Rigidbody, Collider>(
+            [this](ecs::Entity e, Transform& t, Rigidbody& rb, Collider& c)
+            {
+                m_Proxies.push_back(Proxy{e, &t, &rb, &c, AABB{}});
+            });
+
+        Integrate(dt);
+        ResolveTerrain();
+        ResolveCollisions();
+    }
+
+    void PhysicsWorld::Integrate(float dt)
+    {
+        for (Proxy& p : m_Proxies)
+        {
+            Rigidbody& rb = *p.body;
+            if (rb.isStatic || rb.invMass == 0.0f)
+            {
+                rb.onGround = false;
+                rb.accumulatedForce = glm::vec3(0.0f);
+                continue;
+            }
+
+            if (rb.useGravity)
+                rb.velocity += gravity * dt;
+            rb.velocity += rb.accumulatedForce * rb.invMass * dt;
+            rb.velocity *= std::max(0.0f, 1.0f - rb.linearDamping * dt);
+
+            p.transform->position += rb.velocity * dt;
+
+            rb.onGround = false;
+            rb.accumulatedForce = glm::vec3(0.0f);
+        }
+    }
+
+    void PhysicsWorld::ResolveTerrain()
+    {
+        if (!sampleTerrainHeight)
+            return;
+
+        for (Proxy& p : m_Proxies)
+        {
+            Rigidbody& rb = *p.body;
+            if (rb.isStatic || rb.invMass == 0.0f)
+                continue;
+
+            const glm::vec3 center = p.transform->position + p.collider->localOffset * p.transform->scale;
+            const float bottom = (p.collider->type == ColliderType::Sphere)
+                                     ? center.y - p.collider->radius * p.transform->scale.y
+                                     : center.y - p.collider->halfExtents.y * p.transform->scale.y;
+
+            const float ground = sampleTerrainHeight(center.x, center.z);
+            if (bottom < ground)
+            {
+                p.transform->position.y += (ground - bottom);
+
+                if (rb.velocity.y < 0.0f)
+                    rb.velocity.y = (rb.restitution > 0.05f) ? -rb.velocity.y * rb.restitution : 0.0f;
+
+                // Ground friction on the horizontal velocity.
+                const float keep = std::max(0.0f, 1.0f - rb.friction);
+                rb.velocity.x *= keep;
+                rb.velocity.z *= keep;
+                rb.onGround = true;
+            }
+        }
+    }
+
+    void PhysicsWorld::ResolveCollisions()
+    {
+        const std::size_t n = m_Proxies.size();
+        if (n < 2)
+            return;
+
+        // Refresh world bounds after integration / terrain clamping.
+        for (Proxy& p : m_Proxies)
+            p.bounds = WorldAABB(*p.transform, *p.collider);
+
+        // ---- Broadphase: spatial hash -> unique candidate pairs --------------
+        const float inv = 1.0f / std::max(0.001f, broadphaseCellSize);
+        std::unordered_map<std::int64_t, std::vector<int>> grid;
+        grid.reserve(n * 2);
+
+        auto cellOf = [inv](float v) { return static_cast<int>(std::floor(v * inv)); };
+
+        for (int i = 0; i < static_cast<int>(n); ++i)
+        {
+            const AABB& b = m_Proxies[i].bounds;
+            for (int x = cellOf(b.min.x); x <= cellOf(b.max.x); ++x)
+                for (int y = cellOf(b.min.y); y <= cellOf(b.max.y); ++y)
+                    for (int z = cellOf(b.min.z); z <= cellOf(b.max.z); ++z)
+                        grid[CellKey(x, y, z)].push_back(i);
+        }
+
+        std::unordered_set<std::uint64_t> seen;
+        std::vector<std::pair<int, int>> pairs;
+        for (auto& cell : grid)
+        {
+            std::vector<int>& bucket = cell.second;
+            for (std::size_t a = 0; a < bucket.size(); ++a)
+                for (std::size_t b = a + 1; b < bucket.size(); ++b)
+                {
+                    const int i = bucket[a];
+                    const int j = bucket[b];
+                    const Rigidbody& ra = *m_Proxies[i].body;
+                    const Rigidbody& rb = *m_Proxies[j].body;
+                    if (ra.invMass == 0.0f && rb.invMass == 0.0f)
+                        continue;
+                    if (!m_Proxies[i].bounds.Intersects(m_Proxies[j].bounds))
+                        continue;
+                    if (seen.insert(PairKey(i, j)).second)
+                        pairs.emplace_back(i, j);
+                }
+        }
+
+        // ---- Narrow-phase + sequential impulse resolution --------------------
+        for (int iter = 0; iter < solverIterations; ++iter)
+        {
+            for (auto& pr : pairs)
+            {
+                Proxy& A = m_Proxies[pr.first];
+                Proxy& B = m_Proxies[pr.second];
+
+                // Bounds may have shifted from a previous iteration's correction.
+                A.bounds = WorldAABB(*A.transform, *A.collider);
+                B.bounds = WorldAABB(*B.transform, *B.collider);
+
+                const Manifold m = ComputeManifold(A, B);
+                if (!m.colliding)
+                    continue;
+                if (A.collider->isTrigger || B.collider->isTrigger)
+                    continue; // overlap only; no physical response
+
+                Rigidbody& a = *A.body;
+                Rigidbody& b = *B.body;
+                const float invSum = a.invMass + b.invMass;
+                if (invSum <= 0.0f)
+                    continue;
+
+                glm::vec3 rv = b.velocity - a.velocity;
+                const float velAlongN = glm::dot(rv, m.normal);
+                if (velAlongN < 0.0f) // bodies approaching
+                {
+                    const float e = std::min(a.restitution, b.restitution);
+                    const float j = -(1.0f + e) * velAlongN / invSum;
+                    const glm::vec3 impulse = j * m.normal;
+                    a.velocity -= impulse * a.invMass;
+                    b.velocity += impulse * b.invMass;
+
+                    // Coulomb friction along the tangent.
+                    rv = b.velocity - a.velocity;
+                    glm::vec3 tangent = rv - glm::dot(rv, m.normal) * m.normal;
+                    const float tl = glm::length(tangent);
+                    if (tl > 1e-6f)
+                    {
+                        tangent /= tl;
+                        const float jt = -glm::dot(rv, tangent) / invSum;
+                        const float mu = std::sqrt(a.friction * b.friction);
+                        const glm::vec3 frictionImpulse =
+                            (std::fabs(jt) < j * mu) ? jt * tangent : -j * mu * tangent;
+                        a.velocity -= frictionImpulse * a.invMass;
+                        b.velocity += frictionImpulse * b.invMass;
+                    }
+                }
+
+                // Baumgarte positional correction to fight sinking.
+                const float corr = std::max(m.penetration - penetrationSlop, 0.0f) / invSum * positionalCorrection;
+                const glm::vec3 c = corr * m.normal;
+                A.transform->position -= c * a.invMass;
+                B.transform->position += c * b.invMass;
+            }
+        }
+    }
+
+    RaycastHit PhysicsWorld::RaycastTerrain(const Ray& ray, float maxDistance) const
+    {
+        RaycastHit out;
+        if (!sampleTerrainHeight)
+            return out;
+
+        const float step = std::max(0.5f, broadphaseCellSize * 0.5f);
+        float prevT = 0.0f;
+        float prevDiff = ray.origin.y - sampleTerrainHeight(ray.origin.x, ray.origin.z);
+
+        for (float t = step; t <= maxDistance; t += step)
+        {
+            const glm::vec3 p = ray.At(t);
+            const float diff = p.y - sampleTerrainHeight(p.x, p.z);
+            if (diff <= 0.0f && prevDiff > 0.0f)
+            {
+                float lo = prevT, hi = t;
+                for (int i = 0; i < 8; ++i) // bisect onto the surface
+                {
+                    const float mid = 0.5f * (lo + hi);
+                    const glm::vec3 pm = ray.At(mid);
+                    if (pm.y - sampleTerrainHeight(pm.x, pm.z) > 0.0f)
+                        lo = mid;
+                    else
+                        hi = mid;
+                }
+                const float th = 0.5f * (lo + hi);
+                const glm::vec3 ph = ray.At(th);
+                out.hit = true;
+                out.distance = th;
+                out.point = ph;
+                out.normal = sampleTerrainNormal ? sampleTerrainNormal(ph.x, ph.z) : glm::vec3(0.0f, 1.0f, 0.0f);
+                return out;
+            }
+            prevDiff = diff;
+            prevT = t;
+        }
+        return out;
+    }
+
+    RaycastHit PhysicsWorld::Raycast(ecs::Registry& registry, const Ray& ray, float maxDistance)
+    {
+        m_Proxies.clear();
+        registry.View<Transform, Rigidbody, Collider>(
+            [this](ecs::Entity e, Transform& t, Rigidbody& rb, Collider& c)
+            {
+                m_Proxies.push_back(Proxy{e, &t, &rb, &c, WorldAABB(t, c)});
+            });
+
+        RaycastHit best;
+        best.distance = maxDistance;
+
+        for (Proxy& p : m_Proxies)
+        {
+            RaycastHit h = (p.collider->type == ColliderType::Box)
+                               ? RayVsAABB(ray, p.bounds)
+                               : RayVsSphere(ray, WorldSphere(*p.transform, *p.collider));
+            if (h.hit && h.distance >= 0.0f && h.distance < best.distance)
+            {
+                best = h;
+                best.entity = p.entity;
+            }
+        }
+
+        const RaycastHit terrain = RaycastTerrain(ray, maxDistance);
+        if (terrain.hit && terrain.distance < best.distance)
+        {
+            best = terrain;
+            best.entity = ecs::kNull;
+        }
+
+        return best;
+    }
+}

--- a/K.Engine.Terrain/include/HeightField.hpp
+++ b/K.Engine.Terrain/include/HeightField.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#include <glm.hpp>
+#include <Shapes.hpp>
+#include <vector>
+#include <cstdint>
+
+namespace KDot
+{
+    // A regular grid of height samples in world space. This is the single source
+    // of truth for terrain elevation: chunk meshing reads it, sculpting writes
+    // it, and physics queries it for ground height/normal. Sampling is bilinear
+    // so it stays smooth between grid points and independent of mesh LOD.
+    class HeightField
+    {
+    public:
+        HeightField() = default;
+        HeightField(int width, int depth, float cellSize, const glm::vec3& origin = glm::vec3(0.0f));
+
+        int   Width()    const { return m_Width; }   // sample count along X
+        int   Depth()    const { return m_Depth; }   // sample count along Z
+        float CellSize() const { return m_CellSize; }
+        const glm::vec3& Origin() const { return m_Origin; }
+
+        // World extent covered by the field (X and Z spans).
+        float WorldSizeX() const { return (m_Width - 1) * m_CellSize; }
+        float WorldSizeZ() const { return (m_Depth - 1) * m_CellSize; }
+
+        bool InBounds(int i, int j) const
+        {
+            return i >= 0 && i < m_Width && j >= 0 && j < m_Depth;
+        }
+
+        std::size_t Index(int i, int j) const { return static_cast<std::size_t>(j) * m_Width + i; }
+
+        // Raw grid access (clamped to the edge so callers never read out of range).
+        float GetRaw(int i, int j) const;
+        void  SetRaw(int i, int j, float h);
+        void  AddRaw(int i, int j, float delta);
+
+        std::vector<float>&       Data()       { return m_Heights; }
+        const std::vector<float>& Data() const { return m_Heights; }
+
+        // World-space world position of grid sample (i, j).
+        glm::vec3 WorldPosition(int i, int j) const
+        {
+            return m_Origin + glm::vec3(i * m_CellSize, GetRaw(i, j), j * m_CellSize);
+        }
+
+        // Bilinear height at an arbitrary world (x, z).
+        float HeightAtWorld(float worldX, float worldZ) const;
+        // Smooth surface normal at an arbitrary world (x, z) via central differences.
+        glm::vec3 NormalAtWorld(float worldX, float worldZ) const;
+
+        AABB Bounds() const;
+
+    private:
+        int   m_Width = 0;
+        int   m_Depth = 0;
+        float m_CellSize = 1.0f;
+        glm::vec3 m_Origin{0.0f};
+        std::vector<float> m_Heights;
+    };
+}

--- a/K.Engine.Terrain/include/Terrain.hpp
+++ b/K.Engine.Terrain/include/Terrain.hpp
@@ -1,0 +1,77 @@
+#pragma once
+#include <HeightField.hpp>
+#include <TerrainChunk.hpp>
+#include <Core/Noise.hpp>
+#include <glm.hpp>
+#include <vector>
+#include <cstdint>
+
+namespace KDot
+{
+    enum class SculptMode
+    {
+        Raise,   // push terrain up
+        Lower,   // push terrain down
+        Flatten, // pull toward the brush's average height
+        Smooth,  // blur with neighbours
+        Set      // pull toward an explicit target height
+    };
+
+    struct TerrainConfig
+    {
+        int       chunksX = 4;
+        int       chunksZ = 4;
+        float     cellSize = 1.0f;
+        glm::vec3 origin{0.0f};
+        float     heightScale = 60.0f;
+        NoiseParams noise;
+        bool      useRidged = false; // ridged multifractal (mountains) vs fBm
+        bool      useWarp   = true;  // domain warping for organic shapes
+        std::uint32_t seed  = 1337;
+        TerrainChunkConfig chunk; // chunkEdge etc. (pulled from QualitySettings)
+    };
+
+    // -------------------------------------------------------------------------
+    // Terrain
+    //
+    //  Owns the heightfield + a grid of LOD chunks. Generate() builds the field
+    //  from noise; Update(camera) picks a LOD per chunk from QualitySettings and
+    //  rebuilds only what changed; Sculpt() edits the field at runtime; HeightAt/
+    //  NormalAt feed the physics world.
+    // -------------------------------------------------------------------------
+    class Terrain
+    {
+    public:
+        Terrain() = default;
+
+        void Generate(const TerrainConfig& cfg);
+        void Update(const glm::vec3& cameraPos);
+
+        void Sculpt(const glm::vec2& worldXZ, float radius, float strength,
+                    SculptMode mode, float dt = 1.0f, float targetHeight = 0.0f);
+
+        float     HeightAt(float x, float z) const { return m_Field.HeightAtWorld(x, z); }
+        glm::vec3 NormalAt(float x, float z) const { return m_Field.NormalAtWorld(x, z); }
+
+        const HeightField& Field() const { return m_Field; }
+        HeightField&       Field()       { return m_Field; }
+
+        const std::vector<TerrainChunk>& Chunks() const { return m_Chunks; }
+        std::vector<TerrainChunk>&       Chunks()       { return m_Chunks; }
+
+        AABB Bounds() const { return m_Field.Bounds(); }
+        int  MaxLOD() const;
+
+        // Total triangles across all currently-built chunk meshes (for stats/UI).
+        std::size_t TriangleCount() const;
+
+    private:
+        float SampleNoise(float worldX, float worldZ) const;
+        void  MarkDirtyInRadius(const glm::vec2& worldXZ, float radius);
+        glm::vec3 ChunkCenterWorld(int chunkX, int chunkZ) const;
+
+        TerrainConfig m_Cfg;
+        HeightField   m_Field;
+        std::vector<TerrainChunk> m_Chunks; // row-major: index = cz * chunksX + cx
+    };
+}

--- a/K.Engine.Terrain/include/TerrainChunk.hpp
+++ b/K.Engine.Terrain/include/TerrainChunk.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#include <HeightField.hpp>
+#include <Core/MeshData.hpp>
+#include <Shapes.hpp>
+#include <glm.hpp>
+
+namespace KDot
+{
+    // Tunables shared by every chunk: how dense a chunk is at LOD0, how deep the
+    // crack-hiding skirts hang, and the height/slope bands used to tint the
+    // surface (a lightweight stand-in for full material splatting).
+    struct TerrainChunkConfig
+    {
+        int   chunkEdge   = 65;    // vertices per edge at LOD0 (must be 2^n + 1)
+        float skirtDepth  = 3.0f;  // 0 disables skirts
+
+        float sandMaxHeight  = 2.0f;
+        float grassMaxHeight = 35.0f;
+        float rockMaxHeight  = 70.0f;
+        float slopeRockThreshold = 0.72f; // normal.y below this => exposed rock
+    };
+
+    // One square tile of the heightfield. Rebuilds its mesh on demand whenever
+    // its LOD changes or it is marked dirty by a sculpt edit.
+    class TerrainChunk
+    {
+    public:
+        TerrainChunk() = default;
+        TerrainChunk(int chunkX, int chunkZ) : m_ChunkX(chunkX), m_ChunkZ(chunkZ) {}
+
+        int  ChunkX() const { return m_ChunkX; }
+        int  ChunkZ() const { return m_ChunkZ; }
+        int  LOD()    const { return m_LOD; }
+        bool Dirty()  const { return m_Dirty; }
+        void MarkDirty() { m_Dirty = true; }
+
+        const MeshData& Mesh()   const { return m_Mesh; }
+        const AABB&     Bounds() const { return m_Bounds; }
+        glm::vec3       Center() const { return m_Center; }
+
+        // (Re)generate the mesh for the given LOD. No-op if already built at that
+        // LOD and not dirty.
+        void Build(const HeightField& field, int lod, const TerrainChunkConfig& cfg);
+
+    private:
+        static glm::vec4 ColorFor(float height, const glm::vec3& normal, const TerrainChunkConfig& cfg);
+
+        int  m_ChunkX = 0;
+        int  m_ChunkZ = 0;
+        int  m_LOD = -1;
+        bool m_Dirty = true;
+        MeshData  m_Mesh;
+        AABB      m_Bounds;
+        glm::vec3 m_Center{0.0f};
+    };
+}

--- a/K.Engine.Terrain/src/HeightField.cpp
+++ b/K.Engine.Terrain/src/HeightField.cpp
@@ -1,0 +1,84 @@
+#include <HeightField.hpp>
+#include <algorithm>
+
+namespace KDot
+{
+    HeightField::HeightField(int width, int depth, float cellSize, const glm::vec3& origin)
+        : m_Width(std::max(2, width)),
+          m_Depth(std::max(2, depth)),
+          m_CellSize(cellSize),
+          m_Origin(origin),
+          m_Heights(static_cast<std::size_t>(std::max(2, width)) * std::max(2, depth), 0.0f)
+    {
+    }
+
+    float HeightField::GetRaw(int i, int j) const
+    {
+        i = std::clamp(i, 0, m_Width - 1);
+        j = std::clamp(j, 0, m_Depth - 1);
+        return m_Heights[Index(i, j)];
+    }
+
+    void HeightField::SetRaw(int i, int j, float h)
+    {
+        if (InBounds(i, j))
+            m_Heights[Index(i, j)] = h;
+    }
+
+    void HeightField::AddRaw(int i, int j, float delta)
+    {
+        if (InBounds(i, j))
+            m_Heights[Index(i, j)] += delta;
+    }
+
+    float HeightField::HeightAtWorld(float worldX, float worldZ) const
+    {
+        // Fractional grid coordinates.
+        const float gx = (worldX - m_Origin.x) / m_CellSize;
+        const float gz = (worldZ - m_Origin.z) / m_CellSize;
+
+        const int i0 = static_cast<int>(std::floor(gx));
+        const int j0 = static_cast<int>(std::floor(gz));
+        const float fx = gx - i0;
+        const float fz = gz - j0;
+
+        const float h00 = GetRaw(i0,     j0);
+        const float h10 = GetRaw(i0 + 1, j0);
+        const float h01 = GetRaw(i0,     j0 + 1);
+        const float h11 = GetRaw(i0 + 1, j0 + 1);
+
+        const float hx0 = h00 + (h10 - h00) * fx;
+        const float hx1 = h01 + (h11 - h01) * fx;
+        return m_Origin.y + hx0 + (hx1 - hx0) * fz;
+    }
+
+    glm::vec3 HeightField::NormalAtWorld(float worldX, float worldZ) const
+    {
+        const float d = m_CellSize;
+        const float hl = HeightAtWorld(worldX - d, worldZ);
+        const float hr = HeightAtWorld(worldX + d, worldZ);
+        const float hd = HeightAtWorld(worldX, worldZ - d);
+        const float hu = HeightAtWorld(worldX, worldZ + d);
+        // Gradient -> surface normal. The +y component is 2*d so steeper slopes
+        // tilt the normal proportionally.
+        return glm::normalize(glm::vec3(hl - hr, 2.0f * d, hd - hu));
+    }
+
+    AABB HeightField::Bounds() const
+    {
+        float lo = 0.0f, hi = 0.0f;
+        if (!m_Heights.empty())
+        {
+            lo = hi = m_Heights[0];
+            for (float h : m_Heights)
+            {
+                lo = std::min(lo, h);
+                hi = std::max(hi, h);
+            }
+        }
+        AABB box;
+        box.min = m_Origin + glm::vec3(0.0f, lo, 0.0f);
+        box.max = m_Origin + glm::vec3(WorldSizeX(), hi, WorldSizeZ());
+        return box;
+    }
+}

--- a/K.Engine.Terrain/src/Terrain.cpp
+++ b/K.Engine.Terrain/src/Terrain.cpp
@@ -1,0 +1,207 @@
+#include <Terrain.hpp>
+#include <Core/QualitySettings.hpp>
+#include <algorithm>
+#include <cmath>
+
+namespace KDot
+{
+    float Terrain::SampleNoise(float worldX, float worldZ) const
+    {
+        const glm::vec2 p{worldX, worldZ};
+        float h;
+        if (m_Cfg.useRidged)
+            h = Noise::Ridged(p, m_Cfg.noise);
+        else if (m_Cfg.useWarp)
+            h = Noise::Warped(p, m_Cfg.noise);
+        else
+            h = Noise::FBM(p, m_Cfg.noise);
+        return h * m_Cfg.heightScale;
+    }
+
+    void Terrain::Generate(const TerrainConfig& cfg)
+    {
+        m_Cfg = cfg;
+
+        // Seed the noise field deterministically.
+        const float so = static_cast<float>(m_Cfg.seed) * 0.6180339887f;
+        m_Cfg.noise.offset += glm::vec2(so, so * 1.7f);
+
+        const int cells = m_Cfg.chunk.chunkEdge - 1;
+        const int width = m_Cfg.chunksX * cells + 1;
+        const int depth = m_Cfg.chunksZ * cells + 1;
+
+        m_Field = HeightField(width, depth, m_Cfg.cellSize, m_Cfg.origin);
+
+        for (int j = 0; j < depth; ++j)
+        {
+            for (int i = 0; i < width; ++i)
+            {
+                const float wx = m_Cfg.origin.x + i * m_Cfg.cellSize;
+                const float wz = m_Cfg.origin.z + j * m_Cfg.cellSize;
+                m_Field.SetRaw(i, j, SampleNoise(wx, wz));
+            }
+        }
+
+        // Build the chunk grid; start each at the coarsest LOD so geometry exists
+        // before the first Update() refines it near the camera.
+        m_Chunks.clear();
+        m_Chunks.reserve(static_cast<std::size_t>(m_Cfg.chunksX) * m_Cfg.chunksZ);
+        const int coarse = MaxLOD();
+        for (int cz = 0; cz < m_Cfg.chunksZ; ++cz)
+            for (int cx = 0; cx < m_Cfg.chunksX; ++cx)
+            {
+                TerrainChunk chunk(cx, cz);
+                chunk.Build(m_Field, coarse, m_Cfg.chunk);
+                m_Chunks.push_back(std::move(chunk));
+            }
+    }
+
+    int Terrain::MaxLOD() const
+    {
+        // Coarsest LOD allowed by the chunk's cell count (cells == 2^k).
+        int cells = m_Cfg.chunk.chunkEdge - 1;
+        int byCells = 0;
+        while (cells > 1 && (cells % 2) == 0) { cells /= 2; ++byCells; }
+
+        const int byQuality = std::max(0, QualitySettings::Get().maxLODLevels - 1);
+        return std::min(byCells, byQuality);
+    }
+
+    glm::vec3 Terrain::ChunkCenterWorld(int chunkX, int chunkZ) const
+    {
+        const int cells = m_Cfg.chunk.chunkEdge - 1;
+        const float wx = m_Cfg.origin.x + (chunkX * cells + cells * 0.5f) * m_Cfg.cellSize;
+        const float wz = m_Cfg.origin.z + (chunkZ * cells + cells * 0.5f) * m_Cfg.cellSize;
+        return glm::vec3(wx, m_Field.HeightAtWorld(wx, wz), wz);
+    }
+
+    void Terrain::Update(const glm::vec3& cameraPos)
+    {
+        const int maxLevels = MaxLOD() + 1;
+        const QualitySettings& q = QualitySettings::Get();
+
+        for (TerrainChunk& chunk : m_Chunks)
+        {
+            const glm::vec3 center = ChunkCenterWorld(chunk.ChunkX(), chunk.ChunkZ());
+            const float dist = glm::distance(cameraPos, center);
+            const int lod = std::min(MaxLOD(), q.SelectLOD(dist, maxLevels));
+            chunk.Build(m_Field, lod, m_Cfg.chunk); // no-op unless LOD changed or dirty
+        }
+    }
+
+    void Terrain::MarkDirtyInRadius(const glm::vec2& worldXZ, float radius)
+    {
+        const int cells = m_Cfg.chunk.chunkEdge - 1;
+        const float pad = radius + m_Cfg.cellSize;
+
+        // Affected grid-sample range.
+        const float giMin = (worldXZ.x - pad - m_Cfg.origin.x) / m_Cfg.cellSize;
+        const float giMax = (worldXZ.x + pad - m_Cfg.origin.x) / m_Cfg.cellSize;
+        const float gjMin = (worldXZ.y - pad - m_Cfg.origin.z) / m_Cfg.cellSize;
+        const float gjMax = (worldXZ.y + pad - m_Cfg.origin.z) / m_Cfg.cellSize;
+
+        for (TerrainChunk& chunk : m_Chunks)
+        {
+            const int lo_i = chunk.ChunkX() * cells;
+            const int hi_i = lo_i + cells;
+            const int lo_j = chunk.ChunkZ() * cells;
+            const int hi_j = lo_j + cells;
+
+            const bool overlapX = static_cast<float>(lo_i) <= giMax && static_cast<float>(hi_i) >= giMin;
+            const bool overlapZ = static_cast<float>(lo_j) <= gjMax && static_cast<float>(hi_j) >= gjMin;
+            if (overlapX && overlapZ)
+                chunk.MarkDirty();
+        }
+    }
+
+    void Terrain::Sculpt(const glm::vec2& worldXZ, float radius, float strength,
+                         SculptMode mode, float dt, float targetHeight)
+    {
+        if (radius <= 0.0f)
+            return;
+
+        const float r = radius / m_Cfg.cellSize; // radius in grid units
+        const float cgx = (worldXZ.x - m_Cfg.origin.x) / m_Cfg.cellSize;
+        const float cgz = (worldXZ.y - m_Cfg.origin.z) / m_Cfg.cellSize;
+
+        const int iMin = std::max(0, static_cast<int>(std::floor(cgx - r)));
+        const int iMax = std::min(m_Field.Width() - 1, static_cast<int>(std::ceil(cgx + r)));
+        const int jMin = std::max(0, static_cast<int>(std::floor(cgz - r)));
+        const int jMax = std::min(m_Field.Depth() - 1, static_cast<int>(std::ceil(cgz + r)));
+        if (iMin > iMax || jMin > jMax)
+            return;
+
+        // Flatten needs the average height of the affected region up front.
+        float average = targetHeight;
+        if (mode == SculptMode::Flatten)
+        {
+            double sum = 0.0; int count = 0;
+            for (int j = jMin; j <= jMax; ++j)
+                for (int i = iMin; i <= iMax; ++i)
+                {
+                    const float dx = i - cgx, dz = j - cgz;
+                    if (dx * dx + dz * dz <= r * r) { sum += m_Field.GetRaw(i, j); ++count; }
+                }
+            if (count > 0) average = static_cast<float>(sum / count);
+        }
+
+        // Smooth reads from a snapshot so the blur doesn't feed back on itself.
+        std::vector<float> snapshot;
+        if (mode == SculptMode::Smooth)
+            snapshot = m_Field.Data();
+
+        for (int j = jMin; j <= jMax; ++j)
+        {
+            for (int i = iMin; i <= iMax; ++i)
+            {
+                const float dx = i - cgx, dz = j - cgz;
+                const float d2 = dx * dx + dz * dz;
+                if (d2 > r * r)
+                    continue;
+
+                // Smooth radial falloff (1 at centre -> 0 at edge).
+                const float falloff = 1.0f - (d2 / (r * r));
+                const float w = falloff * falloff;
+                const float amt = strength * w * dt;
+
+                switch (mode)
+                {
+                    case SculptMode::Raise: m_Field.AddRaw(i, j, amt);  break;
+                    case SculptMode::Lower: m_Field.AddRaw(i, j, -amt); break;
+                    case SculptMode::Flatten:
+                    case SculptMode::Set:
+                    {
+                        const float target = (mode == SculptMode::Set) ? targetHeight : average;
+                        const float cur = m_Field.GetRaw(i, j);
+                        m_Field.SetRaw(i, j, cur + (target - cur) * std::min(1.0f, w * std::max(strength, 0.0f) * dt));
+                        break;
+                    }
+                    case SculptMode::Smooth:
+                    {
+                        auto sample = [&](int si, int sj) {
+                            si = std::clamp(si, 0, m_Field.Width() - 1);
+                            sj = std::clamp(sj, 0, m_Field.Depth() - 1);
+                            return snapshot[static_cast<std::size_t>(sj) * m_Field.Width() + si];
+                        };
+                        const float avg = (sample(i - 1, j) + sample(i + 1, j) +
+                                           sample(i, j - 1) + sample(i, j + 1) +
+                                           sample(i, j)) * 0.2f;
+                        const float cur = m_Field.GetRaw(i, j);
+                        m_Field.SetRaw(i, j, cur + (avg - cur) * std::min(1.0f, w * dt));
+                        break;
+                    }
+                }
+            }
+        }
+
+        MarkDirtyInRadius(worldXZ, radius);
+    }
+
+    std::size_t Terrain::TriangleCount() const
+    {
+        std::size_t total = 0;
+        for (const TerrainChunk& c : m_Chunks)
+            total += c.Mesh().TriangleCount();
+        return total;
+    }
+}

--- a/K.Engine.Terrain/src/TerrainChunk.cpp
+++ b/K.Engine.Terrain/src/TerrainChunk.cpp
@@ -1,0 +1,122 @@
+#include <TerrainChunk.hpp>
+#include <algorithm>
+
+namespace KDot
+{
+    glm::vec4 TerrainChunk::ColorFor(float height, const glm::vec3& normal, const TerrainChunkConfig& cfg)
+    {
+        const glm::vec3 sand {0.76f, 0.70f, 0.45f};
+        const glm::vec3 grass{0.28f, 0.46f, 0.18f};
+        const glm::vec3 rock {0.40f, 0.36f, 0.32f};
+        const glm::vec3 snow {0.92f, 0.94f, 0.97f};
+
+        glm::vec3 base;
+        if (height < cfg.sandMaxHeight)
+            base = sand;
+        else if (height < cfg.grassMaxHeight)
+        {
+            const float t = (height - cfg.sandMaxHeight) / std::max(0.001f, cfg.grassMaxHeight - cfg.sandMaxHeight);
+            base = glm::mix(sand, grass, glm::clamp(t * 3.0f, 0.0f, 1.0f));
+        }
+        else if (height < cfg.rockMaxHeight)
+        {
+            const float t = (height - cfg.grassMaxHeight) / std::max(0.001f, cfg.rockMaxHeight - cfg.grassMaxHeight);
+            base = glm::mix(grass, rock, glm::clamp(t, 0.0f, 1.0f));
+        }
+        else
+            base = snow;
+
+        // Steep faces show rock regardless of altitude.
+        const float slope = glm::clamp((cfg.slopeRockThreshold - normal.y) / std::max(0.001f, cfg.slopeRockThreshold), 0.0f, 1.0f);
+        base = glm::mix(base, rock, slope);
+
+        return glm::vec4(base, 1.0f);
+    }
+
+    void TerrainChunk::Build(const HeightField& field, int lod, const TerrainChunkConfig& cfg)
+    {
+        if (lod == m_LOD && !m_Dirty)
+            return;
+
+        const int cells  = cfg.chunkEdge - 1;        // cells per chunk edge at LOD0
+        const int stride = 1 << lod;                 // skip factor for this LOD
+        const int n      = cells / stride + 1;       // vertices per edge at this LOD
+        const int baseI  = m_ChunkX * cells;         // grid sample offset
+        const int baseJ  = m_ChunkZ * cells;
+
+        m_Mesh.Clear();
+        m_Mesh.vertices.reserve(static_cast<std::size_t>(n) * n);
+        m_Mesh.indices.reserve(static_cast<std::size_t>(n - 1) * (n - 1) * 6);
+
+        // ---- Surface vertices --------------------------------------------------
+        for (int j = 0; j < n; ++j)
+        {
+            for (int i = 0; i < n; ++i)
+            {
+                const int gi = baseI + i * stride;
+                const int gj = baseJ + j * stride;
+                const glm::vec3 pos = field.WorldPosition(gi, gj);
+                const glm::vec3 nrm = field.NormalAtWorld(pos.x, pos.z);
+
+                MeshVertex v;
+                v.position = pos;
+                v.normal   = nrm;
+                v.color    = ColorFor(pos.y, nrm, cfg);
+                v.texCoord = glm::vec2(static_cast<float>(i) / (n - 1), static_cast<float>(j) / (n - 1));
+                v.texIndex = 0;
+                m_Mesh.vertices.push_back(v);
+            }
+        }
+
+        // ---- Surface indices (CCW when viewed from +Y) -------------------------
+        auto idx = [n](int i, int j) { return static_cast<std::uint32_t>(j * n + i); };
+        for (int j = 0; j < n - 1; ++j)
+        {
+            for (int i = 0; i < n - 1; ++i)
+            {
+                const std::uint32_t a = idx(i,     j);
+                const std::uint32_t b = idx(i,     j + 1);
+                const std::uint32_t c = idx(i + 1, j + 1);
+                const std::uint32_t d = idx(i + 1, j);
+                m_Mesh.indices.push_back(a); m_Mesh.indices.push_back(b); m_Mesh.indices.push_back(c);
+                m_Mesh.indices.push_back(a); m_Mesh.indices.push_back(c); m_Mesh.indices.push_back(d);
+            }
+        }
+
+        // ---- Skirts: double-sided vertical walls around the perimeter that drop
+        //      below the surface, hiding gaps where a neighbour uses a coarser LOD.
+        if (cfg.skirtDepth > 0.0f)
+        {
+            auto addWall = [&](std::uint32_t t0, std::uint32_t t1)
+            {
+                MeshVertex s0 = m_Mesh.vertices[t0]; s0.position.y -= cfg.skirtDepth;
+                MeshVertex s1 = m_Mesh.vertices[t1]; s1.position.y -= cfg.skirtDepth;
+                const std::uint32_t b0 = static_cast<std::uint32_t>(m_Mesh.vertices.size()); m_Mesh.vertices.push_back(s0);
+                const std::uint32_t b1 = static_cast<std::uint32_t>(m_Mesh.vertices.size()); m_Mesh.vertices.push_back(s1);
+                // front winding
+                m_Mesh.indices.push_back(t0); m_Mesh.indices.push_back(t1); m_Mesh.indices.push_back(b1);
+                m_Mesh.indices.push_back(t0); m_Mesh.indices.push_back(b1); m_Mesh.indices.push_back(b0);
+                // back winding (so the wall is visible from either side)
+                m_Mesh.indices.push_back(t0); m_Mesh.indices.push_back(b1); m_Mesh.indices.push_back(t1);
+                m_Mesh.indices.push_back(t0); m_Mesh.indices.push_back(b0); m_Mesh.indices.push_back(b1);
+            };
+
+            for (int i = 0; i < n - 1; ++i) addWall(idx(i, 0),     idx(i + 1, 0));        // -Z edge
+            for (int i = 0; i < n - 1; ++i) addWall(idx(i, n - 1), idx(i + 1, n - 1));    // +Z edge
+            for (int j = 0; j < n - 1; ++j) addWall(idx(0, j),     idx(0, j + 1));        // -X edge
+            for (int j = 0; j < n - 1; ++j) addWall(idx(n - 1, j), idx(n - 1, j + 1));    // +X edge
+        }
+
+        // ---- Bounds + center ---------------------------------------------------
+        if (!m_Mesh.vertices.empty())
+        {
+            m_Bounds.min = m_Bounds.max = m_Mesh.vertices[0].position;
+            for (const MeshVertex& v : m_Mesh.vertices)
+                m_Bounds.Encapsulate(v.position);
+        }
+        m_Center = m_Bounds.Center();
+
+        m_LOD = lod;
+        m_Dirty = false;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,30 +1,94 @@
 # K.Engine
 <img width="1918" height="922" alt="image" src="https://github.com/user-attachments/assets/531c1653-c5fd-4161-ad41-7502e279f715" />
 
-K.Engine is a simple WIP game engine written in C++.
+K.Engine is a WIP custom game engine written in C++, targeting a fidelity level
+**roughly two-thirds of the way from Iruna Online to Elden Ring (~0.65)** with a
+single, runtime-adjustable detail dial.
 
-You can test the current development build [here](https://bellaire-games-studio.github.io/K.Engine/build/bin/K.Engine.html)
-The build folder holds a current build of the repository
+You can test the current development build [here](https://bellaire-games-studio.github.io/K.Engine/build/bin/K.Engine.html).
+The build folder holds a current build of the repository.
 
 ## Features
 
 - [ ] 2D Rendering
 - [X] 3D Rendering
+- [X] Procedural Terrain (chunked, LOD, runtime sculpting)
+- [X] Physics (rigidbody, AABB/sphere, raycasts, terrain collision)
+- [X] Entity Component System
+- [X] Adjustable fidelity / LOD ("0.65" dial)
 - [ ] Audio
-- [ ] Physics
 - [ ] Animation
-- [X] Online/In-browser
+- [X] Online/In-browser (Emscripten / WebGL2)
+- [ ] Native Windows / Linux *(roadmap)*
+- [ ] WebGPU backend *(roadmap)*
 - [ ] Multithreading
 
+## Modules
 
-## Building
+| Module | Contents |
+| --- | --- |
+| `K.Engine.Core` | Application loop, window, layer stack, ImGui editor shell, demo |
+| `K.Engine.Graphics` | Batched renderer (quads/cubes), `DrawMesh` for terrain, camera, lights |
+| `K.Engine.Physics` | Shapes, collision manifolds, rigidbodies, `PhysicsWorld` (broadphase + solver), raycasts |
+| `K.Engine.Terrain` | `HeightField`, LOD `TerrainChunk` meshing, `Terrain` (noise gen + sculpting) |
+| `K.Engine.Common` | ECS, math, events, `QualitySettings` dial, `Transform`, `MeshData`, noise |
+| `K.Engine.Input` | Keyboard/mouse polling, platform window |
 
-### Windows
+## The fidelity dial
 
-- Install [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/)
-- Install [CMake](https://cmake.org/download/)
-- Install [Git](https://git-scm.com/downloads)
-- Install [Emscripten](https://emscripten.org/docs/getting_started/downloads.html) choco install emscripten
+Everything detail-related reads from one master value in `QualitySettings`
+(`K.Engine.Common/include/Core/QualitySettings.hpp`), in the range `[0, 1]`:
+
+```cpp
+KDot::QualitySettings::Get().SetFidelity(0.65f); // project default
+```
+
+| Fidelity | Render dist | Terrain chunk edge | Max LOD | Shadows |
+| --- | --- | --- | --- | --- |
+| 0.00 (Iruna)   | 120  | 17  | 2 | off |
+| 0.65 (K.Engine)| ~1730| 65  | 5 | 2048 |
+| 1.00 (Elden)   | 2600 | 129 | 6 | 4096 |
+
+Changing it at runtime (there's a slider in the demo's Inspector panel)
+re-derives render distance, LOD bands, terrain density, shadow map size, light
+budget and texture sampling, so a settings menu only ever touches one call.
+
+## Terrain
+
+- Heightfield generated from multi-octave simplex noise with optional **domain
+  warping** (organic shapes) and **ridged multifractal** (mountains).
+- Tiled into chunks, each meshed at a **LOD chosen per-frame from camera distance**.
+- **Double-sided skirts** hide cracks between chunks at differing LODs.
+- Height/slope-based vertex tinting (sand → grass → rock → snow) as a stand-in
+  for full material splatting.
+- **Runtime sculpting**: raise / lower / flatten / smooth / set with a radial brush.
+- The same heightfield feeds physics ground collision and raycasts.
+
+## Physics
+
+- `Rigidbody` + `Collider` (box / sphere) components stepped over the ECS.
+- Semi-implicit Euler integration, **spatial-hash broadphase**, sequential-impulse
+  resolution with friction and Baumgarte positional correction.
+- Heightfield ground collision and world raycasts (against colliders + terrain).
+
+## Roadmap: cross-platform & WebGPU
+
+The new gameplay systems (terrain, physics, ECS, config, math) are deliberately
+**graphics-API-agnostic** — pure C++/GLM with no GL coupling — so they already
+compile toward any backend. The remaining cross-platform work is isolated to the
+window + render layers:
+
+1. Abstract the window/main-loop off Emscripten (native GLFW + a desktop game loop).
+2. Add a desktop GL path (glad/GLEW) behind the existing `Renderer` so Windows/Linux build.
+3. Introduce a small RHI seam and a **WebGPU (Dawn/wgpu)** backend behind it.
+
+## Building (web)
+
+- Install [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/), [CMake](https://cmake.org/download/), [Git](https://git-scm.com/downloads), and [Emscripten](https://emscripten.org/docs/getting_started/downloads.html)
 - Clone the repository
 - run `build.bat`
 - Open `build/bin/K.Engine.html` in your browser
+
+The platform-agnostic modules (Physics / Terrain / Common) can also be compiled
+and unit-tested with a normal host compiler (e.g. `g++ -std=c++17 -I glm ...`),
+which is how they are validated independently of the WebGL build.


### PR DESCRIPTION
## Summary
This PR brings together four major subsystems to create a playable physics-driven terrain demo: a procedurally generated, LOD'd terrain system; a spatial-hash physics engine with rigidbody dynamics and collision resolution; a lightweight entity-component system; and a unified quality/fidelity dial that drives all detail levels across the engine.

## Key Changes

**Physics Engine (`K.Engine.Physics`)**
- New `PhysicsWorld` class implementing semi-implicit Euler integration, terrain collision, and impulse-based contact resolution
- Spatial-hash broadphase with 64-bit cell keys and unique pair tracking
- Narrow-phase collision detection for AABB/sphere combinations via `Collision` namespace
- `Rigidbody` component with mass, damping, restitution, and friction properties
- `Collider` component supporting box and sphere shapes with local offsets and scaling
- Analytic ray-casting against shapes and terrain for gameplay/editor queries

**Terrain System (`K.Engine.Terrain`)**
- `HeightField` class: regular grid of height samples with bilinear interpolation for smooth queries independent of mesh LOD
- `Terrain` class: manages a grid of `TerrainChunk` tiles, each with runtime LOD selection based on camera distance
- `TerrainChunk`: generates indexed triangle meshes from the heightfield at variable LOD levels, with height-based tinting (sand/grass/rock/snow) and slope-driven rock exposure
- Procedural generation via Perlin noise (fBm, ridged, and domain-warped variants) with deterministic seeding
- Runtime sculpting support via `MarkDirtyInRadius()` and `Sculpt()` methods

**Entity-Component System (`K.Engine.Common/EntitityComponentSystem`)**
- Header-only sparse-set ECS with 32-bit entity handles (20-bit index + 12-bit version)
- `Registry` managing typed component pools with cache-friendly dense storage
- `View<>` template for iteration over entities with specific component combinations
- Swap-remove semantics for O(1) component removal while maintaining pack density

**Quality Settings (`K.Engine.Common/Core`)**
- Unified `QualitySettings` singleton with a master "fidelity dial" [0, 1] mapping to six tiers (Iruna → Elden Ring)
- Derived parameters: render distance, LOD band distances, terrain chunk density, shadow map resolution, texture anisotropy, MSAA samples
- Runtime-adjustable with automatic recomputation of all dependent values
- Default target: 0.65 (two-thirds toward high fidelity)

**Supporting Infrastructure**
- `Transform` component: position, quaternion rotation, scale
- `Shapes.hpp`: geometric primitives (AABB, Sphere, Ray, Plane) with analytic intersection tests
- `Noise.hpp`: fractal Brownian motion, ridged multifractal, and domain-warped noise helpers
- `MeshData.hpp`: CPU-side mesh representation (vertices + indices) for terrain and future geometry sources

**Demo Integration (`K.Engine.Core`)**
- Renamed `Tetris` layer to `WorldLayer` demonstrating the full stack
- Spawns a physics-driven ball that falls and settles on procedurally generated terrain
- Editor panel for real-time terrain sculpting and fidelity adjustment
- Fly camera with terrain LOD updates based on distance

## Notable Implementation Details

- Physics solver uses Baumgarte positional correction to stabilize stacking and prevent jitter
- Terrain chunks rebuild only when LOD changes or marked dirty, avoiding redundant meshing
- Spatial hash uses 21-bit cell coordinates per axis (64-bit key) to support large worlds
- Noise seeding via golden ratio ensures deterministic, non-repeating terrain across different seeds
- Collider bounds refresh after integration and terrain clamping to keep broadphase accurate
- ECS version bits prevent use-after-free bugs from stale entity handles
